### PR TITLE
Fix: while loops is running constantly and keeps processor busy

### DIFF
--- a/src/transport/udp_transport.cpp
+++ b/src/transport/udp_transport.cpp
@@ -280,6 +280,9 @@ void UdpTransport::receive_loop() {
                     listener_->on_message_received(message, sender);
                 }
             }
+        } else if (result == Result::TIMEOUT) {
+            // No data available, sleep briefly to avoid busy-wait
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         } else if (result == Result::NETWORK_ERROR) {
             // Network error, notify listener
             if (listener_) {


### PR DESCRIPTION
I was running the hello_world_server and client and noticed tha tthe fan of my notebook went up- I checked the system monitor and one of my cores were kept busy by the hello_world_server. After some debugging I have seen that the while loop is the root cause. I just suggest a fix. Feel free to check it 