### PR TITLE
fix(docs): remove 'status' from needs_extra_options

### DIFF
--- a/docs/requirements/conf.py
+++ b/docs/requirements/conf.py
@@ -71,13 +71,13 @@ needs_types = [
 ]
 
 # Extra options for needs
+# Note: 'status' is a core field in sphinx-needs and should not be listed here
 needs_extra_options = [
     "satisfies",
     "implements",
     "tested_by",
     "code_location",
     "priority",
-    "status",
 ]
 
 # Extra links for traceability


### PR DESCRIPTION
'status' is now a core field in sphinx-needs and cannot be added as an extra option. This fixes the documentation build failure in CI.