### PR TITLE
fix(docs): resolve sphinx-needs link type and extra option conflict

### DIFF
--- a/.github/workflows/publish-requirements.yml
+++ b/.github/workflows/publish-requirements.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install sphinx>=5.0 sphinx-needs>=0.6.0 sphinxcontrib-plantuml
+          pip install sphinx>=7.0 sphinx-needs>=5.0.0 sphinxcontrib-plantuml
           pip install -r open-someip-spec/requirements.txt
 
       - name: Build open-someip-spec

--- a/.github/workflows/requirements-validation.yml
+++ b/.github/workflows/requirements-validation.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install sphinx>=5.0 sphinx-needs>=0.6.0
+          pip install sphinx>=7.0 sphinx-needs>=5.0.0
 
       - name: Extract code requirements
         run: |

--- a/docs/requirements/conf.py
+++ b/docs/requirements/conf.py
@@ -71,11 +71,10 @@ needs_types = [
 ]
 
 # Extra options for needs
-# Note: 'status' is a core field in sphinx-needs and should not be listed here
+# Note: 'status' is a core field in sphinx-needs and should not be listed here.
+# Link types (satisfies, implements, tested_by) are defined in needs_extra_links
+# and automatically create their own options, so they must not be duplicated here.
 needs_extra_options = [
-    "satisfies",
-    "implements",
-    "tested_by",
     "code_location",
     "priority",
 ]

--- a/docs/requirements/requirements.txt
+++ b/docs/requirements/requirements.txt
@@ -1,0 +1,4 @@
+# Sphinx documentation dependencies for OpenSOMEIP requirements
+sphinx>=7.0.0
+sphinx-needs>=5.0.0
+sphinxcontrib-plantuml>=0.30

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -145,6 +145,9 @@ install_python_packages() {
     echo "📦 Installing Python packages with $PIP_CMD..."
     $PIP_CMD install --user gcovr pytest pytest-cov
 
+    echo "📦 Installing documentation packages..."
+    $PIP_CMD install --user sphinx sphinx-needs sphinxcontrib-plantuml
+
     echo "✅ Python packages installed"
 }
 
@@ -198,6 +201,8 @@ echo "- cppcheck (additional static analysis)"
 echo "- lcov (coverage reporting, optional)"
 echo "- gcovr (Python coverage reporting)"
 echo "- pytest (Python testing framework)"
+echo "- sphinx (documentation generator)"
+echo "- sphinx-needs (requirements management)"
 echo ""
 
 read -p "Continue with installation? (y/N): " -n 1 -r


### PR DESCRIPTION
In sphinx-needs >=5.0, link types defined in needs_extra_links automatically create their own options. Having the same names (satisfies, implements, tested_by) in both needs_extra_options and needs_extra_links causes a build error.

- Remove duplicate link type names from needs_extra_options
- Update CI workflows to require sphinx-needs>=5.0.0
- Add sphinx-needs to install_dev_tools.sh for local development
- Add docs/requirements/requirements.txt for documentation deps