### PR TITLE
fix(build): use CMAKE_CURRENT_SOURCE_DIR for VERSION file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@
 cmake_minimum_required(VERSION 3.20)
 
 # Read version from VERSION file
-file(READ "${CMAKE_SOURCE_DIR}/VERSION" PROJECT_VERSION)
+# Use CMAKE_CURRENT_SOURCE_DIR to support being used as a subdirectory
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" PROJECT_VERSION)
 string(STRIP "${PROJECT_VERSION}" PROJECT_VERSION)
 
 project(someip-stack VERSION ${PROJECT_VERSION} LANGUAGES CXX)


### PR DESCRIPTION
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR when reading the VERSION file to support being used as a CMake subdirectory/submodule in other projects.