### PR TITLE
ci: skip build and tests on documentation-only changes

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -8,20 +8,16 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - 'open-someip-spec/**'
+      - '!docs/requirements/**'
       - 'LICENSE'
-      - 'CONTRIBUTING.md'
-      - 'CHANGELOG.md'
       - '.cursor/**'
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - 'open-someip-spec/**'
+      - '!docs/requirements/**'
       - 'LICENSE'
-      - 'CONTRIBUTING.md'
-      - 'CHANGELOG.md'
       - '.cursor/**'
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to ignore documentation, license, and auxiliary cursor-related files for push and pull request triggers. This reduces unnecessary workflow runs, making continuous integration more efficient and lowering noise from doc/config-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->