### PR TITLE
fix(docker): pin pip package versions for reproducible dev image builds

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,9 +37,8 @@ RUN HOSTARCH=$(uname -m) && \
     && ln -sf /opt/cmake-${CMAKE_VERSION}-linux-${HOSTARCH}/bin/* /usr/local/bin/
 
 # Python: host test deps + Zephyr build deps
-RUN pip3 install --no-cache-dir \
-    west pyelftools pyyaml pykwalify packaging canopen jsonschema \
-    pytest pytest-cov coverage junit-xml
+COPY requirements-dev.txt /tmp/requirements-dev.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements-dev.txt
 
 # Zephyr SDK (minimal + host tools + ARM cross-compiler)
 RUN HOSTARCH=$(uname -m) && \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+west==1.5.0
+pyelftools==0.32
+pyyaml==6.0.3
+pykwalify==1.8.0
+packaging==26.0
+canopen==2.4.1
+jsonschema==4.26.0
+pytest==9.0.2
+pytest-cov==7.0.0
+coverage==7.13.4
+junit-xml==1.9


### PR DESCRIPTION
## Summary
- Extract pip dependencies into `requirements-dev.txt` with pinned versions
- Update `Dockerfile.dev` to install via the requirements file
- Prevents future silent build breakage when upstream packages release incompatible changes

Closes #23

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment setup by centralizing dependency management for enhanced consistency and maintainability across development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->