### PR TITLE
ci(freertos): add --no-tests=error to ctest to prevent false-green builds

### DIFF
--- a/.github/workflows/freertos.yml
+++ b/.github/workflows/freertos.yml
@@ -49,4 +49,4 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -S ${{ github.workspace }}
           cmake --build build_freertos_rt --config Release
-          cd build_freertos_rt && ctest --output-on-failure --timeout 30
+          cd build_freertos_rt && ctest --output-on-failure --timeout 30 --no-tests=error


### PR DESCRIPTION
## Summary
- Add `--no-tests=error` to the ctest invocation in the FreeRTOS runtime-tests job
- Prevents CI from silently passing when zero tests are discovered

Closes #26

Made with [Cursor](https://cursor.com)