### PR TITLE
docs: add SOMEIP_FREERTOS_LINUX_TESTS to build options table

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -192,6 +192,7 @@ make
 | `SOMEIP_USE_FREERTOS` | OFF | Use FreeRTOS threading backend (see [FREERTOS_PORT.md](FREERTOS_PORT.md)) |
 | `SOMEIP_USE_THREADX` | OFF | Use ThreadX threading backend (see [THREADX_PORT.md](THREADX_PORT.md)) |
 | `SOMEIP_USE_LWIP` | OFF | Use lwIP networking backend |
+| `SOMEIP_FREERTOS_LINUX_TESTS` | OFF | Fetch FreeRTOS POSIX port and build runtime tests |
 | `SOMEIP_THREADX_LINUX_TESTS` | OFF | Fetch ThreadX linux port and build runtime tests |
 
 ### Safety Options


### PR DESCRIPTION
## Summary
- Add missing `SOMEIP_FREERTOS_LINUX_TESTS` row to the Build Options table in `docs/BUILD.md`

Closes #28

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new build configuration option that allows enabling FreeRTOS POSIX port functionality and runtime tests. This option is disabled by default and can be activated as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->