### PR TITLE
fix(stubs): guard lwIP byte-order helpers for big-endian hosts

### DIFF
--- a/tests/stubs/lwip/lwip/def.h
+++ b/tests/stubs/lwip/lwip/def.h
@@ -7,7 +7,12 @@
 #include <stdint.h>
 
 static inline uint16_t lwip_htons(uint16_t x) {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return (uint16_t)((x >> 8) | (x << 8));
+#else
+    return x;
+#endif
 }
 
 static inline uint16_t lwip_ntohs(uint16_t x) {
@@ -15,10 +20,15 @@ static inline uint16_t lwip_ntohs(uint16_t x) {
 }
 
 static inline uint32_t lwip_htonl(uint32_t x) {
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return ((x >> 24) & 0x000000FFU) |
            ((x >>  8) & 0x0000FF00U) |
            ((x <<  8) & 0x00FF0000U) |
            ((x << 24) & 0xFF000000U);
+#else
+    return x;
+#endif
 }
 
 static inline uint32_t lwip_ntohl(uint32_t x) {


### PR DESCRIPTION
## Summary
- Wrap the byte-swap logic in `lwip_htons`/`lwip_htonl` (and their `ntoh*` aliases) with `__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__` guards
- On big-endian hosts the helpers now return the input unchanged (no-op), which is the correct POSIX semantics

Closes #29

Made with [Cursor](https://cursor.com)