### PR TITLE
fix(tests): check tx_thread_create return value and fail fast on error

### DIFF
--- a/tests/threadx/test_threadx_core.cpp
+++ b/tests/threadx/test_threadx_core.cpp
@@ -188,15 +188,19 @@ static void test_thread_entry(ULONG) {
 }
 
 extern "C" void tx_application_define(void*) {
-    tx_thread_create(&test_thread,
-                     const_cast<CHAR*>("test_main"),
-                     test_thread_entry,
-                     0,
-                     test_stack,
-                     sizeof(test_stack),
-                     1, 1,
-                     TX_NO_TIME_SLICE,
-                     TX_AUTO_START);
+    UINT rc = tx_thread_create(&test_thread,
+                               const_cast<CHAR*>("test_main"),
+                               test_thread_entry,
+                               0,
+                               test_stack,
+                               sizeof(test_stack),
+                               1, 1,
+                               TX_NO_TIME_SLICE,
+                               TX_AUTO_START);
+    if (rc != TX_SUCCESS) {
+        std::fprintf(stderr, "tx_thread_create failed: %u\n", rc);
+        std::exit(1);
+    }
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- Capture the `UINT` return value of `tx_thread_create` in `tx_application_define`
- Print an error message and call `std::exit(1)` on any non-`TX_SUCCESS` result
- Mirrors the error-handling pattern already used in `thread_impl.h`

Closes #30

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error detection and handling in test execution with proper verification of thread creation operations and early termination on critical failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->