### PR TITLE
ci(threadx): add --no-tests=error to ctest to prevent false-green builds

### DIFF
--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -49,4 +49,4 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -S ${{ github.workspace }}
           cmake --build build_threadx_rt --config Release
-          cd build_threadx_rt && ctest --output-on-failure --timeout 30
+          cd build_threadx_rt && ctest --output-on-failure --timeout 30 --no-tests=error


### PR DESCRIPTION
## Summary
- Add `--no-tests=error` to the ctest invocation in the ThreadX runtime-tests job
- Prevents CI from silently passing when zero tests are discovered

Closes #33

Made with [Cursor](https://cursor.com)