### PR TITLE
fix(ci): use correct Coverity project name and download encoding

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -52,8 +52,7 @@ jobs:
       - name: Download Coverity Build Tool
         run: |
           curl -fsS \
-            --form "token=${COVERITY_SCAN_TOKEN}" \
-            --form "project=vtz-opensomeip" \
+            -d "token=${COVERITY_SCAN_TOKEN}&project=vtz/opensomeip" \
             -o coverity_tool.tgz \
             https://scan.coverity.com/download/linux64
           mkdir -p coverity_tool
@@ -78,4 +77,4 @@ jobs:
             --form file=@analysis-results.tgz \
             --form version="${{ github.sha }}" \
             --form description="Automated Coverity Scan from GitHub Actions" \
-            https://scan.coverity.com/builds?project=vtz-opensomeip
+            https://scan.coverity.com/builds?project=vtz/opensomeip


### PR DESCRIPTION
## Summary

- Use actual Coverity project name `vtz/opensomeip` instead of URL slug `vtz-opensomeip` in both download and submit API calls
- Switch download endpoint from multipart form (`--form`) to URL-encoded POST data (`-d`), matching the Coverity Scan API expectations

Fixes the 401 authentication error on the Coverity Scan workflow.

## Test plan

- [x] Verified locally that `curl -d "token=...&project=vtz/opensomeip" https://scan.coverity.com/download/linux64` succeeds
- [ ] Merge and confirm the full workflow completes on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build system configuration and submission parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->