### PR TITLE
fix(msvc): undef Windows ERROR macro in .cpp files using MessageType::ERROR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,16 @@ target_link_libraries(someip-tp PRIVATE someip-core PRIVATE someip-transport)
 # Create convenience aliases for backward compatibility
 add_library(someip-common ALIAS someip-core)
 
+# On Windows, <windows.h> pulls in <wingdi.h> which defines ERROR as a macro.
+# This collides with MessageType::ERROR.  NOGDI suppresses that header entirely;
+# WIN32_LEAN_AND_MEAN trims other unused Win32 sub-headers.
+if(WIN32)
+    foreach(_tgt someip-core-obj someip-e2e-obj someip-serialization
+                 someip-transport someip-rpc someip-sd someip-events someip-tp)
+        target_compile_definitions(${_tgt} PRIVATE NOGDI WIN32_LEAN_AND_MEAN)
+    endforeach()
+endif()
+
 # Set library properties (only on real targets, not aliases)
 set_target_properties(someip-core someip-serialization someip-transport PROPERTIES
     VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
## Summary

- Fixes MSVC build failure (C2589/C2062) caused by the Windows `ERROR` preprocessor macro (from `<wingdi.h>`) colliding with `MessageType::ERROR`.
- Adds `NOGDI` and `WIN32_LEAN_AND_MEAN` compile definitions to all library targets on Windows via CMakeLists.txt, preventing `<wingdi.h>` from being included entirely.
- The existing `#undef ERROR` guard in `types.h` is kept as a safety net for external consumers who include the header without our CMake definitions.

Closes #66

## Approach

Instead of sprinkling `#undef ERROR` in every `.cpp` file that references `MessageType::ERROR`, this uses CMake `target_compile_definitions` with `NOGDI` to prevent `<windows.h>` from pulling in `<wingdi.h>` in the first place. This is safe since a SOME/IP networking library has no use for GDI.

## Test plan

- [x] Local macOS build passes
- [ ] Windows CI build should now pass (previously failing with C2589 on `message.cpp`)
- [ ] All existing unit tests remain green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows build compatibility issues to prevent compilation conflicts and ensure successful application builds on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->