### PR TITLE
fix(pal): MSVC/Windows portability for socket calls and macros

### DIFF
--- a/include/platform/lwip/net_impl.h
+++ b/include/platform/lwip/net_impl.h
@@ -66,4 +66,31 @@ static inline int someip_set_blocking(int fd) {
     return lwip_fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
 }
 
+/* ---------- Portable socket-call wrappers (pass-through on lwIP) ----------- */
+
+#define someip_setsockopt  setsockopt
+#define someip_getsockopt  getsockopt
+#define someip_sendto      sendto
+#define someip_recvfrom    recvfrom
+#define someip_send        send
+#define someip_recv        recv
+
+static inline int someip_set_socket_timeout(int fd, int optname,
+                                            int timeout_ms) {
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    return setsockopt(fd, SOL_SOCKET, optname, &tv, sizeof(tv));
+}
+
+/* ---------- Error reporting (pass-through on lwIP) ------------------------- */
+
+static inline int someip_socket_errno() { return errno; }
+
+#define SOMEIP_EAGAIN      EAGAIN
+#define SOMEIP_EWOULDBLOCK EWOULDBLOCK
+#define SOMEIP_EINPROGRESS EINPROGRESS
+#define SOMEIP_EBADF       EBADF
+#define SOMEIP_EINTR       EINTR
+
 #endif // SOMEIP_PLATFORM_LWIP_NET_IMPL_H

--- a/include/platform/posix/net_impl.h
+++ b/include/platform/posix/net_impl.h
@@ -38,4 +38,31 @@ static inline int someip_set_blocking(int fd) {
     return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
 }
 
+/* ---------- Portable socket-call wrappers (pass-through on POSIX) ---------- */
+
+#define someip_setsockopt  setsockopt
+#define someip_getsockopt  getsockopt
+#define someip_sendto      sendto
+#define someip_recvfrom    recvfrom
+#define someip_send        send
+#define someip_recv        recv
+
+static inline int someip_set_socket_timeout(int fd, int optname,
+                                            int timeout_ms) {
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    return setsockopt(fd, SOL_SOCKET, optname, &tv, sizeof(tv));
+}
+
+/* ---------- Error reporting (pass-through on POSIX) ------------------------ */
+
+static inline int someip_socket_errno() { return errno; }
+
+#define SOMEIP_EAGAIN      EAGAIN
+#define SOMEIP_EWOULDBLOCK EWOULDBLOCK
+#define SOMEIP_EINPROGRESS EINPROGRESS
+#define SOMEIP_EBADF       EBADF
+#define SOMEIP_EINTR       EINTR
+
 #endif // SOMEIP_PLATFORM_POSIX_NET_IMPL_H

--- a/include/platform/win32/net_impl.h
+++ b/include/platform/win32/net_impl.h
@@ -9,7 +9,10 @@
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <BaseTsd.h>
 #pragma comment(lib, "ws2_32.lib")
+
+using ssize_t = SSIZE_T;
 
 #define someip_close_socket(fd) closesocket(fd)
 #define someip_shutdown_socket(fd) shutdown(fd, SD_BOTH)
@@ -23,5 +26,70 @@ static inline int someip_set_blocking(int fd) {
     u_long mode = 0;
     return (ioctlsocket(fd, FIONBIO, &mode) == 0) ? 0 : -1;
 }
+
+/* ---------- Portable socket-call wrappers (Winsock uses char* not void*) --- */
+
+/** @implements REQ_PAL_NET_SOCKOPT */
+static inline int someip_setsockopt(int fd, int level, int optname,
+                                    const void* optval, int optlen) {
+    return setsockopt(fd, level, optname,
+                      reinterpret_cast<const char*>(optval), optlen);
+}
+
+/** @implements REQ_PAL_NET_SOCKOPT */
+static inline int someip_getsockopt(int fd, int level, int optname,
+                                    void* optval, socklen_t* optlen) {
+    return getsockopt(fd, level, optname,
+                      reinterpret_cast<char*>(optval),
+                      reinterpret_cast<int*>(optlen));
+}
+
+/** @implements REQ_PAL_NET_SEND */
+static inline ssize_t someip_sendto(int fd, const void* buf, size_t len,
+                                    int flags, const struct sockaddr* dest,
+                                    socklen_t addrlen) {
+    return sendto(fd, reinterpret_cast<const char*>(buf),
+                  static_cast<int>(len), flags, dest, addrlen);
+}
+
+/** @implements REQ_PAL_NET_RECV */
+static inline ssize_t someip_recvfrom(int fd, void* buf, size_t len,
+                                      int flags, struct sockaddr* src,
+                                      socklen_t* addrlen) {
+    return recvfrom(fd, reinterpret_cast<char*>(buf),
+                    static_cast<int>(len), flags, src, addrlen);
+}
+
+/** @implements REQ_PAL_NET_SEND */
+static inline ssize_t someip_send(int fd, const void* buf, size_t len,
+                                  int flags) {
+    return send(fd, reinterpret_cast<const char*>(buf),
+                static_cast<int>(len), flags);
+}
+
+/** @implements REQ_PAL_NET_RECV */
+static inline ssize_t someip_recv(int fd, void* buf, size_t len, int flags) {
+    return recv(fd, reinterpret_cast<char*>(buf),
+                static_cast<int>(len), flags);
+}
+
+/* ---------- Socket timeout helper (Windows uses DWORD ms, not timeval) ----- */
+
+static inline int someip_set_socket_timeout(int fd, int optname,
+                                            int timeout_ms) {
+    DWORD ms = static_cast<DWORD>(timeout_ms);
+    return setsockopt(fd, SOL_SOCKET, optname,
+                      reinterpret_cast<const char*>(&ms), sizeof(ms));
+}
+
+/* ---------- Error reporting (Winsock uses WSAGetLastError, not errno) ------- */
+
+static inline int someip_socket_errno() { return WSAGetLastError(); }
+
+#define SOMEIP_EAGAIN      WSAEWOULDBLOCK
+#define SOMEIP_EWOULDBLOCK WSAEWOULDBLOCK
+#define SOMEIP_EINPROGRESS WSAEWOULDBLOCK  /* non-blocking connect() */
+#define SOMEIP_EBADF       WSAENOTSOCK
+#define SOMEIP_EINTR       WSAEINTR
 
 #endif // SOMEIP_PLATFORM_WIN32_NET_IMPL_H

--- a/include/platform/zephyr/net_impl.h
+++ b/include/platform/zephyr/net_impl.h
@@ -87,4 +87,31 @@ static inline int someip_set_blocking(int fd) {
     return zsock_fcntl(fd, ZVFS_F_SETFL, flags & ~ZVFS_O_NONBLOCK);
 }
 
+/* ---------- Portable socket-call wrappers (pass-through on Zephyr) --------- */
+
+#define someip_setsockopt  setsockopt
+#define someip_getsockopt  getsockopt
+#define someip_sendto      sendto
+#define someip_recvfrom    recvfrom
+#define someip_send        send
+#define someip_recv        recv
+
+static inline int someip_set_socket_timeout(int fd, int optname,
+                                            int timeout_ms) {
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    return setsockopt(fd, SOL_SOCKET, optname, &tv, sizeof(tv));
+}
+
+/* ---------- Error reporting (pass-through on Zephyr) ----------------------- */
+
+static inline int someip_socket_errno() { return errno; }
+
+#define SOMEIP_EAGAIN      EAGAIN
+#define SOMEIP_EWOULDBLOCK EWOULDBLOCK
+#define SOMEIP_EINPROGRESS EINPROGRESS
+#define SOMEIP_EBADF       EBADF
+#define SOMEIP_EINTR       EINTR
+
 #endif // SOMEIP_PLATFORM_ZEPHYR_NET_IMPL_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,13 +166,14 @@ target_link_libraries(someip-tp PRIVATE someip-core PRIVATE someip-transport)
 # Create convenience aliases for backward compatibility
 add_library(someip-common ALIAS someip-core)
 
-# On Windows, <windows.h> pulls in <wingdi.h> which defines ERROR as a macro.
-# This collides with MessageType::ERROR.  NOGDI suppresses that header entirely;
-# WIN32_LEAN_AND_MEAN trims other unused Win32 sub-headers.
+# Windows portability: suppress problematic macros from <windows.h>.
+#   NOGDI            – prevents <wingdi.h> (defines ERROR as 0)
+#   WIN32_LEAN_AND_MEAN – trims unused Win32 sub-headers
+#   NOMINMAX         – prevents min/max macros that break std::min/std::max
 if(WIN32)
     foreach(_tgt someip-core-obj someip-e2e-obj someip-serialization
                  someip-transport someip-rpc someip-sd someip-events someip-tp)
-        target_compile_definitions(${_tgt} PRIVATE NOGDI WIN32_LEAN_AND_MEAN)
+        target_compile_definitions(${_tgt} PRIVATE NOGDI WIN32_LEAN_AND_MEAN NOMINMAX)
     endforeach()
 endif()
 

--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -18,7 +18,6 @@
 #include <cstring>
 #include <iostream>
 #include <algorithm>
-#include <cerrno>
 #include <cstdio>
 
 namespace someip {
@@ -270,32 +269,26 @@ Result TcpTransport::setup_socket_options(int socket_fd, bool blocking) {
 #if (!defined(__ZEPHYR__) || defined(CONFIG_ARCH_POSIX)) && !defined(SOMEIP_NET_LWIP)
     if (config_.keep_alive) {
         int keep_alive = 1;
-#ifdef __APPLE__
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPALIVE, &keep_alive, sizeof(keep_alive));
         int keep_alive_interval = static_cast<int>(config_.keep_alive_interval.count() / 1000);
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keep_alive_interval, sizeof(keep_alive_interval));
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPCNT, &keep_alive, sizeof(keep_alive));
+#if defined(__APPLE__)
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPALIVE, &keep_alive, sizeof(keep_alive));
+#elif defined(_WIN32)
+        someip_setsockopt(socket_fd, SOL_SOCKET, SO_KEEPALIVE, &keep_alive, sizeof(keep_alive));
 #else
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keep_alive, sizeof(keep_alive));
-        int keep_alive_interval = static_cast<int>(config_.keep_alive_interval.count() / 1000);
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keep_alive_interval, sizeof(keep_alive_interval));
-        setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPCNT, &keep_alive, sizeof(keep_alive));
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keep_alive, sizeof(keep_alive));
+#endif
+#if !defined(_WIN32)
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keep_alive_interval, sizeof(keep_alive_interval));
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPCNT, &keep_alive, sizeof(keep_alive));
+#else
+        (void)keep_alive_interval;
 #endif
     }
 #endif
 
     // Send/receive timeouts
-    struct timeval send_timeout = {
-        static_cast<time_t>(config_.send_timeout.count() / 1000),
-        static_cast<suseconds_t>((config_.send_timeout.count() % 1000) * 1000)
-    };
-    setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
-
-    struct timeval recv_timeout = {
-        static_cast<time_t>(config_.receive_timeout.count() / 1000),
-        static_cast<suseconds_t>((config_.receive_timeout.count() % 1000) * 1000)
-    };
-    setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, sizeof(recv_timeout));
+    someip_set_socket_timeout(socket_fd, SO_SNDTIMEO, static_cast<int>(config_.send_timeout.count()));
+    someip_set_socket_timeout(socket_fd, SO_RCVTIMEO, static_cast<int>(config_.receive_timeout.count()));
 
     return Result::SUCCESS;
 }
@@ -327,16 +320,15 @@ Result TcpTransport::connect_internal(const Endpoint& endpoint) {
         }
 
         return Result::SUCCESS;
-    } else if (errno == EINPROGRESS) {
+    } else if (someip_socket_errno() == SOMEIP_EINPROGRESS) {
         // Connection in progress - wait for completion
         fd_set write_fds;
         FD_ZERO(&write_fds);
         FD_SET(connection_.socket_fd, &write_fds);
 
-        struct timeval timeout = {
-            static_cast<time_t>(config_.connection_timeout.count() / 1000),
-            static_cast<suseconds_t>((config_.connection_timeout.count() % 1000) * 1000)
-        };
+        struct timeval timeout;
+        timeout.tv_sec  = static_cast<decltype(timeout.tv_sec)>(config_.connection_timeout.count() / 1000);
+        timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>((config_.connection_timeout.count() % 1000) * 1000);
 
         connect_result = select(connection_.socket_fd + 1, nullptr, &write_fds, nullptr, &timeout);
 
@@ -344,7 +336,7 @@ Result TcpTransport::connect_internal(const Endpoint& endpoint) {
             // Check if connection was successful
             int error = 0;
             socklen_t len = sizeof(error);
-            getsockopt(connection_.socket_fd, SOL_SOCKET, SO_ERROR, &error, &len);
+            someip_getsockopt(connection_.socket_fd, SOL_SOCKET, SO_ERROR, &error, &len);
 
             if (error == 0) {
                 connection_.state = TcpConnectionState::CONNECTED;
@@ -485,10 +477,12 @@ Result TcpTransport::send_data(int socket_fd, const std::vector<uint8_t>& data) 
     const uint8_t* buffer = data.data();
 
     while (total_sent < data.size()) {
-        ssize_t sent = send(socket_fd, buffer + total_sent, data.size() - total_sent, 0);
+        ssize_t sent = someip_send(socket_fd, buffer + total_sent,
+                                   data.size() - total_sent, 0);
 
         if (sent < 0) {
-            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            int err = someip_socket_errno();
+            if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK) {
                 continue;  // Retry
             }
             return Result::NETWORK_ERROR;
@@ -511,10 +505,11 @@ Result TcpTransport::receive_data(int socket_fd, std::vector<uint8_t>& data) {
     }
 
     uint8_t buffer[4096];
-    ssize_t received = recv(socket_fd, buffer, max_chunk_size, 0);
+    ssize_t received = someip_recv(socket_fd, buffer, max_chunk_size, 0);
 
     if (received < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        int err = someip_socket_errno();
+        if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK) {
             return Result::SUCCESS;  // No data available
         }
         return Result::NETWORK_ERROR;

--- a/src/transport/udp_transport.cpp
+++ b/src/transport/udp_transport.cpp
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 #include "transport/udp_transport.h"
+#include "platform/net.h"
 #include "platform/memory.h"
 #include "common/result.h"
 #include <cstring>
@@ -186,7 +187,7 @@ Result UdpTransport::join_multicast_group(const std::string& multicast_address) 
     mreq.imr_multiaddr.s_addr = inet_addr(multicast_address.c_str());
     mreq.imr_interface.s_addr = htonl(INADDR_ANY);
 
-    if (setsockopt(socket_fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+    if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
         // In containerized/CI environments, multicast may not be available
         // Continue without multicast support rather than failing
         // This allows SOME/IP to work with unicast-only networking
@@ -194,13 +195,13 @@ Result UdpTransport::join_multicast_group(const std::string& multicast_address) 
 
     // Enable multicast loopback for local testing
     int loop = 1;
-    if (setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop)) < 0) {
+    if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop)) < 0) {
         // Not critical, continue
     }
 
     // Set multicast TTL from config (per SOME/IP spec, default 1 = local network only)
     int ttl = config_.multicast_ttl;
-    if (setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0) {
+    if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0) {
         // Not critical, continue
     }
 
@@ -208,7 +209,7 @@ Result UdpTransport::join_multicast_group(const std::string& multicast_address) 
     if (!config_.multicast_interface.empty()) {
         struct in_addr interface_addr;
         interface_addr.s_addr = inet_addr(config_.multicast_interface.c_str());
-        if (setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_IF, &interface_addr, sizeof(interface_addr)) < 0) {
+        if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_MULTICAST_IF, &interface_addr, sizeof(interface_addr)) < 0) {
             // Not critical, continue
         }
     }
@@ -232,7 +233,7 @@ Result UdpTransport::leave_multicast_group(const std::string& multicast_address)
     mreq.imr_multiaddr.s_addr = inet_addr(multicast_address.c_str());
     mreq.imr_interface.s_addr = htonl(INADDR_ANY);
 
-    if (setsockopt(socket_fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+    if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
         return Result::NETWORK_ERROR;
     }
 
@@ -250,7 +251,7 @@ Result UdpTransport::create_socket() {
     // Set socket options
     if (config_.reuse_address) {
         int reuse = 1;
-        if (setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+        if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
             someip_close_socket(socket_fd_);
             socket_fd_ = -1;
             return Result::NETWORK_ERROR;
@@ -262,7 +263,7 @@ Result UdpTransport::create_socket() {
 #ifdef SO_REUSEPORT
     if (config_.reuse_port) {
         int reuse = 1;
-        if (setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0) {
+        if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0) {
             // Not critical - some systems don't support SO_REUSEPORT
         }
     }
@@ -270,7 +271,7 @@ Result UdpTransport::create_socket() {
 
     if (config_.enable_broadcast) {
         int broadcast = 1;
-        if (setsockopt(socket_fd_, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) < 0) {
+        if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) < 0) {
             someip_close_socket(socket_fd_);
             socket_fd_ = -1;
             return Result::NETWORK_ERROR;
@@ -278,11 +279,13 @@ Result UdpTransport::create_socket() {
     }
 
     // Set buffer sizes (non-critical - may fail in restricted environments like CI/containers)
-    if (setsockopt(socket_fd_, SOL_SOCKET, SO_RCVBUF, &config_.receive_buffer_size, sizeof(config_.receive_buffer_size)) < 0) {
+    int rcvbuf = static_cast<int>(config_.receive_buffer_size);
+    if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) < 0) {
         // Not critical - continue with default buffer size
     }
 
-    if (setsockopt(socket_fd_, SOL_SOCKET, SO_SNDBUF, &config_.send_buffer_size, sizeof(config_.send_buffer_size)) < 0) {
+    int sndbuf = static_cast<int>(config_.send_buffer_size);
+    if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) < 0) {
         // Not critical - continue with default buffer size
     }
 
@@ -332,7 +335,7 @@ Result UdpTransport::configure_multicast(const Endpoint& endpoint) {
         mreq.imr_interface.s_addr = htonl(INADDR_ANY);
     }
 
-    if (setsockopt(socket_fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+    if (someip_setsockopt(socket_fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
         return Result::NETWORK_ERROR;
     }
 
@@ -393,8 +396,9 @@ Result UdpTransport::send_data(const std::vector<uint8_t>& data, const Endpoint&
     }
 
     sockaddr_in dest_addr = create_sockaddr(endpoint);
-    ssize_t sent = sendto(socket_fd_, data.data(), data.size(), 0,
-                         reinterpret_cast<sockaddr*>(&dest_addr), sizeof(dest_addr));
+    ssize_t sent = someip_sendto(socket_fd_, data.data(), data.size(), 0,
+                                reinterpret_cast<sockaddr*>(&dest_addr),
+                                sizeof(dest_addr));
 
     if (sent < 0) {
         return Result::NETWORK_ERROR;
@@ -412,17 +416,18 @@ Result UdpTransport::receive_data(std::vector<uint8_t>& data, Endpoint& sender) 
     sockaddr_in src_addr;
     socklen_t addr_len = sizeof(src_addr);
 
-    ssize_t received = recvfrom(socket_fd_, data.data(), data.size(), 0,
-                               reinterpret_cast<sockaddr*>(&src_addr), &addr_len);
+    ssize_t received = someip_recvfrom(socket_fd_, data.data(), data.size(), 0,
+                                       reinterpret_cast<sockaddr*>(&src_addr),
+                                       &addr_len);
 
     if (received < 0) {
-        // Socket was closed during shutdown
-        if (errno == EBADF || errno == EINTR) {
+        int err = someip_socket_errno();
+
+        if (err == SOMEIP_EBADF || err == SOMEIP_EINTR) {
             return Result::NOT_CONNECTED;
         }
 
-        // In non-blocking mode, EAGAIN/EWOULDBLOCK means no data available
-        if (!config_.blocking && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        if (!config_.blocking && (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK)) {
             return Result::TIMEOUT;
         }
 


### PR DESCRIPTION
## Summary

- Extends the Platform Abstraction Layer with portable socket wrappers that handle POSIX vs Winsock API differences (`void*` vs `char*` buffer types, `errno` vs `WSAGetLastError()`, `struct timeval` vs `DWORD` timeouts)
- Adds `NOMINMAX` to Windows CMake compile definitions, preventing `std::min`/`std::max` macro conflicts
- Replaces all raw `setsockopt`/`sendto`/`recvfrom`/`send`/`recv`/`errno` calls in transport code with portable `someip_*` wrappers

Closes #69

## Files changed

| File | Change |
|------|--------|
| `src/CMakeLists.txt` | Add `NOMINMAX` to Windows compile definitions |
| `include/platform/win32/net_impl.h` | `ssize_t` typedef, socket call wrappers with `reinterpret_cast`, `someip_set_socket_timeout()`, `someip_socket_errno()`, `SOMEIP_E*` error constants |
| `include/platform/posix/net_impl.h` | Pass-through wrappers (macros + inline timeout helper) |
| `include/platform/lwip/net_impl.h` | Pass-through wrappers |
| `include/platform/zephyr/net_impl.h` | Pass-through wrappers |
| `src/transport/udp_transport.cpp` | Use `someip_*` wrappers for all socket and error calls |
| `src/transport/tcp_transport.cpp` | Use `someip_*` wrappers + portable timeout/keepalive setup |

## Issues addressed from #69

1. `serializer.cpp` `std::min` macro conflict → `NOMINMAX` compile definition
2. `udp_transport.cpp` `setsockopt` type mismatch → `someip_setsockopt` wrapper
3. `udp_transport.cpp` `ssize_t` undeclared → typedef in `win32/net_impl.h`
4. `udp_transport.cpp` `sendto`/`recvfrom` buffer type → `someip_sendto`/`someip_recvfrom` wrappers
5. `tcp_transport.cpp` same issues (proactively fixed, not in original issue)

## Test plan

- [x] All 15 existing tests pass (macOS)
- [ ] Windows CI build (pending #68)
- [ ] FreeRTOS, ThreadX, Zephyr cross-compilation unaffected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform socket operation compatibility layer supporting POSIX, Windows, Zephyr, and lwIP environments with standardized error handling.

* **Chores**
  * Updated Windows compilation configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->