### PR TITLE
fix(pal): add in_addr_t typedef for Windows

### DIFF
--- a/include/platform/win32/net_impl.h
+++ b/include/platform/win32/net_impl.h
@@ -13,6 +13,7 @@
 #pragma comment(lib, "ws2_32.lib")
 
 using ssize_t = SSIZE_T;
+using in_addr_t = u_long;
 
 #define someip_close_socket(fd) closesocket(fd)
 #define someip_shutdown_socket(fd) shutdown(fd, SD_BOTH)


### PR DESCRIPTION
## Summary

- Adds `using in_addr_t = u_long;` to `include/platform/win32/net_impl.h`
- Fixes MSVC build failure in `udp_transport.cpp`'s `is_multicast_address()` where `in_addr_t` (a POSIX type from `<netinet/in.h>`) is not available on Windows

One-line fix missed by PR #70.

Closes #79

## Test plan

- [x] Local build passes (macOS)
- [ ] Windows CI build should now pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows platform compatibility through internal type standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->