### PR TITLE
fix: include <errno.h> explicitly in posix/net_impl.h

### DIFF
--- a/include/platform/posix/net_impl.h
+++ b/include/platform/posix/net_impl.h
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 
 /** @implements REQ_PLATFORM_POSIX_003, REQ_PAL_NET_CLOSE */
 #define someip_close_socket(fd) close(fd)


### PR DESCRIPTION
## Summary
- Add missing `#include <errno.h>` to `include/platform/posix/net_impl.h` so the header is self-contained instead of relying on fragile transitive inclusion

## Test plan
- [x] Verify the header compiles independently
- [x] Existing tests continue to pass

Closes #74

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal error handling infrastructure to ensure proper error state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->