### PR TITLE
fix: remove unused <cstdlib> include from threadx/thread_impl.h

### DIFF
--- a/include/platform/threadx/thread_impl.h
+++ b/include/platform/threadx/thread_impl.h
@@ -32,7 +32,6 @@
 #include <tx_api.h>
 
 #include <atomic>
-#include <cstdlib>
 #include <functional>
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
## Summary
- Remove unused `#include <cstdlib>` from `include/platform/threadx/thread_impl.h` — no longer needed since `alloc_slot()` returns `kInvalidSlot` instead of calling `std::abort()`

## Test plan
- [x] Verify no remaining references to `<cstdlib>` symbols in the file
- [x] ThreadX build should continue to compile

Closes #47

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused standard library include from internal header files.

This is a minor internal cleanup with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->