### PR TITLE
fix: retry SOMEIP_EINTR in UDP send_data() and receive_data()

### DIFF
--- a/src/transport/udp_transport.cpp
+++ b/src/transport/udp_transport.cpp
@@ -396,9 +396,12 @@ Result UdpTransport::send_data(const std::vector<uint8_t>& data, const Endpoint&
     }
 
     sockaddr_in dest_addr = create_sockaddr(endpoint);
-    ssize_t sent = someip_sendto(socket_fd_, data.data(), data.size(), 0,
-                                reinterpret_cast<sockaddr*>(&dest_addr),
-                                sizeof(dest_addr));
+    ssize_t sent;
+    do {
+        sent = someip_sendto(socket_fd_, data.data(), data.size(), 0,
+                             reinterpret_cast<sockaddr*>(&dest_addr),
+                             sizeof(dest_addr));
+    } while (sent < 0 && someip_socket_errno() == SOMEIP_EINTR);
 
     if (sent < 0) {
         return Result::NETWORK_ERROR;
@@ -416,14 +419,17 @@ Result UdpTransport::receive_data(std::vector<uint8_t>& data, Endpoint& sender) 
     sockaddr_in src_addr;
     socklen_t addr_len = sizeof(src_addr);
 
-    ssize_t received = someip_recvfrom(socket_fd_, data.data(), data.size(), 0,
-                                       reinterpret_cast<sockaddr*>(&src_addr),
-                                       &addr_len);
+    ssize_t received;
+    do {
+        received = someip_recvfrom(socket_fd_, data.data(), data.size(), 0,
+                                   reinterpret_cast<sockaddr*>(&src_addr),
+                                   &addr_len);
+    } while (received < 0 && someip_socket_errno() == SOMEIP_EINTR);
 
     if (received < 0) {
         int err = someip_socket_errno();
 
-        if (err == SOMEIP_EBADF || err == SOMEIP_EINTR) {
+        if (err == SOMEIP_EBADF) {
             return Result::NOT_CONNECTED;
         }
 


### PR DESCRIPTION
## Summary
- Retry `recvfrom()` on `SOMEIP_EINTR` instead of exiting the receive loop — EINTR is transient (signal interrupt), not a connection error
- Retry `sendto()` on `SOMEIP_EINTR` for the same reason
- Only `SOMEIP_EBADF` now returns `NOT_CONNECTED`

## Test plan
- [x] Verify EINTR no longer causes premature loop exit
- [x] EBADF still correctly exits the receive loop
- [x] EAGAIN/EWOULDBLOCK handling unchanged

Closes #71, closes #72, closes #73

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP network transmission and reception stability by enhancing error handling and recovery mechanisms, resulting in more reliable data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->