### PR TITLE
fix: correct TCP keepalive socket option setup

### DIFF
--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -270,12 +270,11 @@ Result TcpTransport::setup_socket_options(int socket_fd, bool blocking) {
     if (config_.keep_alive) {
         int keep_alive = 1;
         int keep_alive_interval = static_cast<int>(config_.keep_alive_interval.count() / 1000);
-#if defined(__APPLE__)
-        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPALIVE, &keep_alive, sizeof(keep_alive));
-#elif defined(_WIN32)
         someip_setsockopt(socket_fd, SOL_SOCKET, SO_KEEPALIVE, &keep_alive, sizeof(keep_alive));
-#else
-        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keep_alive, sizeof(keep_alive));
+#if defined(__APPLE__)
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPALIVE, &keep_alive_interval, sizeof(keep_alive_interval));
+#elif !defined(_WIN32)
+        someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, &keep_alive_interval, sizeof(keep_alive_interval));
 #endif
 #if !defined(_WIN32)
         someip_setsockopt(socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, &keep_alive_interval, sizeof(keep_alive_interval));


### PR DESCRIPTION
## Summary
- Enable `SO_KEEPALIVE` at `SOL_SOCKET` level on all platforms (was missing on macOS/Linux)
- Pass `keep_alive_interval` instead of the boolean `keep_alive` flag to `TCP_KEEPALIVE` (macOS) / `TCP_KEEPIDLE` (Linux)

## Test plan
- [x] Verify SO_KEEPALIVE is set before platform-specific keepalive options
- [x] Verify correct interval value is passed to idle timeout options
- [x] Windows path unchanged (already had SO_KEEPALIVE)

Closes #76

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TCP connection keep-alive socket options with platform-specific configurations to improve connection stability across Apple, Windows, and other operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->