### PR TITLE
fix: retry SOMEIP_EINTR in TCP send_data() and receive_data()

### DIFF
--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -482,8 +482,8 @@ Result TcpTransport::send_data(int socket_fd, const std::vector<uint8_t>& data) 
 
         if (sent < 0) {
             int err = someip_socket_errno();
-            if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK) {
-                continue;  // Retry
+            if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK || err == SOMEIP_EINTR) {
+                continue;
             }
             return Result::NETWORK_ERROR;
         } else if (sent == 0) {
@@ -509,8 +509,8 @@ Result TcpTransport::receive_data(int socket_fd, std::vector<uint8_t>& data) {
 
     if (received < 0) {
         int err = someip_socket_errno();
-        if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK) {
-            return Result::SUCCESS;  // No data available
+        if (err == SOMEIP_EAGAIN || err == SOMEIP_EWOULDBLOCK || err == SOMEIP_EINTR) {
+            return Result::SUCCESS;  // No data available or interrupted
         }
         return Result::NETWORK_ERROR;
     } else if (received == 0) {


### PR DESCRIPTION
## Summary
- Handle `SOMEIP_EINTR` in TCP `send_data()` by retrying (same as `EAGAIN`/`EWOULDBLOCK`)
- Handle `SOMEIP_EINTR` in TCP `receive_data()` by returning SUCCESS so the receive loop retries
- Previously, EINTR caused a fatal `NETWORK_ERROR` and disconnection

## Test plan
- [x] Verify EINTR in send_data() triggers retry instead of disconnect
- [x] Verify EINTR in receive_data() causes retry instead of disconnect
- [x] EAGAIN/EWOULDBLOCK handling unchanged

Closes #78

Made with [Cursor](https://cursor.com)