### PR TITLE
fix: use portable someip_socket_t for socket handles

### DIFF
--- a/include/platform/lwip/net_impl.h
+++ b/include/platform/lwip/net_impl.h
@@ -47,6 +47,9 @@
 #define inet_pton(...)    lwip_inet_pton(__VA_ARGS__)
 #endif /* !LWIP_COMPAT_SOCKETS */
 
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
+
 /** @implements REQ_PLATFORM_LWIP_001 */
 #define someip_close_socket(fd) lwip_close(fd)
 /** @implements REQ_PLATFORM_LWIP_001 */

--- a/include/platform/posix/net_impl.h
+++ b/include/platform/posix/net_impl.h
@@ -20,6 +20,9 @@
 #include <fcntl.h>
 #include <errno.h>
 
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
+
 /** @implements REQ_PLATFORM_POSIX_003, REQ_PAL_NET_CLOSE */
 #define someip_close_socket(fd) close(fd)
 /** @implements REQ_PAL_NET_SHUTDOWN */

--- a/include/platform/win32/net_impl.h
+++ b/include/platform/win32/net_impl.h
@@ -14,16 +14,18 @@
 
 using ssize_t = SSIZE_T;
 using in_addr_t = u_long;
+using someip_socket_t = SOCKET;
+#define SOMEIP_INVALID_SOCKET INVALID_SOCKET
 
 #define someip_close_socket(fd) closesocket(fd)
 #define someip_shutdown_socket(fd) shutdown(fd, SD_BOTH)
 
-static inline int someip_set_nonblocking(int fd) {
+static inline int someip_set_nonblocking(someip_socket_t fd) {
     u_long mode = 1;
     return (ioctlsocket(fd, FIONBIO, &mode) == 0) ? 0 : -1;
 }
 
-static inline int someip_set_blocking(int fd) {
+static inline int someip_set_blocking(someip_socket_t fd) {
     u_long mode = 0;
     return (ioctlsocket(fd, FIONBIO, &mode) == 0) ? 0 : -1;
 }
@@ -31,14 +33,14 @@ static inline int someip_set_blocking(int fd) {
 /* ---------- Portable socket-call wrappers (Winsock uses char* not void*) --- */
 
 /** @implements REQ_PAL_NET_SOCKOPT */
-static inline int someip_setsockopt(int fd, int level, int optname,
+static inline int someip_setsockopt(someip_socket_t fd, int level, int optname,
                                     const void* optval, int optlen) {
     return setsockopt(fd, level, optname,
                       reinterpret_cast<const char*>(optval), optlen);
 }
 
 /** @implements REQ_PAL_NET_SOCKOPT */
-static inline int someip_getsockopt(int fd, int level, int optname,
+static inline int someip_getsockopt(someip_socket_t fd, int level, int optname,
                                     void* optval, socklen_t* optlen) {
     return getsockopt(fd, level, optname,
                       reinterpret_cast<char*>(optval),
@@ -46,7 +48,7 @@ static inline int someip_getsockopt(int fd, int level, int optname,
 }
 
 /** @implements REQ_PAL_NET_SEND */
-static inline ssize_t someip_sendto(int fd, const void* buf, size_t len,
+static inline ssize_t someip_sendto(someip_socket_t fd, const void* buf, size_t len,
                                     int flags, const struct sockaddr* dest,
                                     socklen_t addrlen) {
     return sendto(fd, reinterpret_cast<const char*>(buf),
@@ -54,7 +56,7 @@ static inline ssize_t someip_sendto(int fd, const void* buf, size_t len,
 }
 
 /** @implements REQ_PAL_NET_RECV */
-static inline ssize_t someip_recvfrom(int fd, void* buf, size_t len,
+static inline ssize_t someip_recvfrom(someip_socket_t fd, void* buf, size_t len,
                                       int flags, struct sockaddr* src,
                                       socklen_t* addrlen) {
     return recvfrom(fd, reinterpret_cast<char*>(buf),
@@ -62,21 +64,21 @@ static inline ssize_t someip_recvfrom(int fd, void* buf, size_t len,
 }
 
 /** @implements REQ_PAL_NET_SEND */
-static inline ssize_t someip_send(int fd, const void* buf, size_t len,
+static inline ssize_t someip_send(someip_socket_t fd, const void* buf, size_t len,
                                   int flags) {
     return send(fd, reinterpret_cast<const char*>(buf),
                 static_cast<int>(len), flags);
 }
 
 /** @implements REQ_PAL_NET_RECV */
-static inline ssize_t someip_recv(int fd, void* buf, size_t len, int flags) {
+static inline ssize_t someip_recv(someip_socket_t fd, void* buf, size_t len, int flags) {
     return recv(fd, reinterpret_cast<char*>(buf),
                 static_cast<int>(len), flags);
 }
 
 /* ---------- Socket timeout helper (Windows uses DWORD ms, not timeval) ----- */
 
-static inline int someip_set_socket_timeout(int fd, int optname,
+static inline int someip_set_socket_timeout(someip_socket_t fd, int optname,
                                             int timeout_ms) {
     DWORD ms = static_cast<DWORD>(timeout_ms);
     return setsockopt(fd, SOL_SOCKET, optname,

--- a/include/platform/zephyr/net_impl.h
+++ b/include/platform/zephyr/net_impl.h
@@ -62,6 +62,8 @@
 #endif
 
 typedef uint32_t in_addr_t;
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
 
 static inline uint32_t someip_zephyr_inet_addr(const char *cp) {
     struct in_addr addr;

--- a/include/transport/tcp_transport.h
+++ b/include/transport/tcp_transport.h
@@ -15,6 +15,7 @@
 #define SOMEIP_TRANSPORT_TCP_TRANSPORT_H
 
 #include "transport/transport.h"
+#include "platform/net.h"
 #include "platform/thread.h"
 #include <cstddef>
 #include <atomic>
@@ -37,7 +38,7 @@ enum class TcpConnectionState : uint8_t {
  * @brief TCP Connection Information
  */
 struct TcpConnection {
-    int socket_fd{-1};
+    someip_socket_t socket_fd{SOMEIP_INVALID_SOCKET};
     Endpoint remote_endpoint;
     TcpConnectionState state{TcpConnectionState::DISCONNECTED};
     std::chrono::steady_clock::time_point last_activity{std::chrono::steady_clock::now()};
@@ -179,7 +180,7 @@ public:
      * @brief Accept incoming connection (server mode)
      * @return New connection socket FD or -1 on error
      */
-    int accept_connection();
+    someip_socket_t accept_connection();
 
 private:
     TcpTransportConfig config_;
@@ -199,18 +200,18 @@ private:
 
     platform::Mutex connection_mutex_;
     bool server_mode_{false};
-    int listen_socket_fd_{-1};
+    someip_socket_t listen_socket_fd_{SOMEIP_INVALID_SOCKET};
 
     // Helper methods
     Result create_socket();
     Result bind_socket();
-    Result setup_socket_options(int socket_fd, bool blocking = true);
+    Result setup_socket_options(someip_socket_t socket_fd, bool blocking = true);
     Result connect_internal(const Endpoint& endpoint);
     void disconnect_internal();
     void receive_loop();
     void connection_monitor_loop();
-    Result send_data(int socket_fd, const std::vector<uint8_t>& data);
-    Result receive_data(int socket_fd, std::vector<uint8_t>& data);
+    Result send_data(someip_socket_t socket_fd, const std::vector<uint8_t>& data);
+    Result receive_data(someip_socket_t socket_fd, std::vector<uint8_t>& data);
     bool parse_message_from_buffer(std::vector<uint8_t>& buffer, MessagePtr& message);
 
     // Message parsing

--- a/include/transport/udp_transport.h
+++ b/include/transport/udp_transport.h
@@ -87,7 +87,7 @@ public:
 private:
     Endpoint local_endpoint_;
     UdpTransportConfig config_;
-    int socket_fd_{-1};
+    someip_socket_t socket_fd_{SOMEIP_INVALID_SOCKET};
     std::atomic<bool> running_;
     std::unique_ptr<platform::Thread> receive_thread_;
     ITransportListener* listener_{nullptr};

--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -153,9 +153,9 @@ Result TcpTransport::stop() {
     disconnect_internal();
 
     // Close listen socket if in server mode
-    if (server_mode_ && listen_socket_fd_ != -1) {
+    if (server_mode_ && listen_socket_fd_ != SOMEIP_INVALID_SOCKET) {
         someip_close_socket(listen_socket_fd_);
-        listen_socket_fd_ = -1;
+        listen_socket_fd_ = SOMEIP_INVALID_SOCKET;
     }
 
     // Wait for threads to finish
@@ -178,7 +178,7 @@ TcpConnectionState TcpTransport::get_connection_state() const {
 }
 
 Result TcpTransport::enable_server_mode(int backlog) {
-    if (connection_.socket_fd == -1) {
+    if (connection_.socket_fd == SOMEIP_INVALID_SOCKET) {
         return Result::NOT_INITIALIZED;
     }
 
@@ -193,9 +193,9 @@ Result TcpTransport::enable_server_mode(int backlog) {
 }
 
 /** @implements REQ_TRANSPORT_003_E01 */
-int TcpTransport::accept_connection() {
-    if (!server_mode_ || listen_socket_fd_ == -1) {
-        return -1;
+someip_socket_t TcpTransport::accept_connection() {
+    if (!server_mode_ || listen_socket_fd_ == SOMEIP_INVALID_SOCKET) {
+        return SOMEIP_INVALID_SOCKET;
     }
 
     // Use select() with a short timeout so the receive_loop can check running_
@@ -204,18 +204,18 @@ int TcpTransport::accept_connection() {
     FD_SET(listen_socket_fd_, &read_fds);
 
     struct timeval tv = {0, 100000}; // 100ms
-    int sel = select(listen_socket_fd_ + 1, &read_fds, nullptr, nullptr, &tv);
+    int sel = select(static_cast<int>(listen_socket_fd_) + 1, &read_fds, nullptr, nullptr, &tv);
     if (sel <= 0) {
-        return -1;
+        return SOMEIP_INVALID_SOCKET;
     }
 
     sockaddr_in client_addr;
     socklen_t client_len = sizeof(client_addr);
 
-    int client_fd = accept(listen_socket_fd_, (sockaddr*)&client_addr, &client_len);
+    someip_socket_t client_fd = accept(listen_socket_fd_, (sockaddr*)&client_addr, &client_len);
 
-    if (client_fd < 0) {
-        return -1;
+    if (client_fd == SOMEIP_INVALID_SOCKET) {
+        return SOMEIP_INVALID_SOCKET;
     }
 
     setup_socket_options(client_fd, true);
@@ -227,7 +227,7 @@ int TcpTransport::accept_connection() {
 
 Result TcpTransport::create_socket() {
     connection_.socket_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (connection_.socket_fd < 0) {
+    if (connection_.socket_fd == SOMEIP_INVALID_SOCKET) {
         return Result::NETWORK_ERROR;
     }
 
@@ -236,7 +236,7 @@ Result TcpTransport::create_socket() {
 }
 
 Result TcpTransport::bind_socket() {
-    if (connection_.socket_fd == -1) {
+    if (connection_.socket_fd == SOMEIP_INVALID_SOCKET) {
         return Result::NOT_INITIALIZED;
     }
 
@@ -254,7 +254,7 @@ Result TcpTransport::bind_socket() {
 }
 
 /** @implements REQ_TRANSPORT_017 */
-Result TcpTransport::setup_socket_options(int socket_fd, bool blocking) {
+Result TcpTransport::setup_socket_options(someip_socket_t socket_fd, bool blocking) {
     if (blocking) {
         if (someip_set_blocking(socket_fd) < 0) {
             return Result::NETWORK_ERROR;
@@ -329,7 +329,7 @@ Result TcpTransport::connect_internal(const Endpoint& endpoint) {
         timeout.tv_sec  = static_cast<decltype(timeout.tv_sec)>(config_.connection_timeout.count() / 1000);
         timeout.tv_usec = static_cast<decltype(timeout.tv_usec)>((config_.connection_timeout.count() % 1000) * 1000);
 
-        connect_result = select(connection_.socket_fd + 1, nullptr, &write_fds, nullptr, &timeout);
+        connect_result = select(static_cast<int>(connection_.socket_fd) + 1, nullptr, &write_fds, nullptr, &timeout);
 
         if (connect_result > 0) {
             int error = 0;
@@ -360,12 +360,12 @@ Result TcpTransport::connect_internal(const Endpoint& endpoint) {
 void TcpTransport::disconnect_internal() {
     platform::ScopedLock lock(connection_mutex_);
 
-    if (connection_.socket_fd != -1) {
+    if (connection_.socket_fd != SOMEIP_INVALID_SOCKET) {
         connection_.state = TcpConnectionState::DISCONNECTING;
 
         someip_shutdown_socket(connection_.socket_fd);
         someip_close_socket(connection_.socket_fd);
-        connection_.socket_fd = -1;
+        connection_.socket_fd = SOMEIP_INVALID_SOCKET;
 
         connection_.state = TcpConnectionState::DISCONNECTED;
 
@@ -385,7 +385,7 @@ void TcpTransport::receive_loop() {
     while (running_) {
         if (server_mode_) {
             // In server mode, accept new connections
-            if (listen_socket_fd_ != -1) {
+            if (listen_socket_fd_ != SOMEIP_INVALID_SOCKET) {
                 // Check connection limit before accepting
                 if (active_connections_.load() >= config_.max_connections) {
                     // Too many connections, wait a bit before checking again
@@ -393,8 +393,8 @@ void TcpTransport::receive_loop() {
                     continue;
                 }
 
-                int client_fd = accept_connection();
-                if (client_fd != -1) {
+                someip_socket_t client_fd = accept_connection();
+                if (client_fd != SOMEIP_INVALID_SOCKET) {
                     // For this simple implementation, we'll handle one client at a time
                     // In a real implementation, you'd manage multiple client connections
                     if (!is_connected()) {
@@ -469,7 +469,7 @@ void TcpTransport::connection_monitor_loop() {
 }
 
 /** @implements REQ_TRANSPORT_002_E01, REQ_TRANSPORT_002_E02, REQ_TRANSPORT_002_E03, REQ_TRANSPORT_002_E04 */
-Result TcpTransport::send_data(int socket_fd, const std::vector<uint8_t>& data) {
+Result TcpTransport::send_data(someip_socket_t socket_fd, const std::vector<uint8_t>& data) {
     size_t total_sent = 0;
     const uint8_t* buffer = data.data();
 
@@ -494,7 +494,7 @@ Result TcpTransport::send_data(int socket_fd, const std::vector<uint8_t>& data) 
 }
 
 /** @implements REQ_TRANSPORT_002_E01, REQ_TRANSPORT_002_E02, REQ_TRANSPORT_002_E03, REQ_TRANSPORT_002_E04 */
-Result TcpTransport::receive_data(int socket_fd, std::vector<uint8_t>& data) {
+Result TcpTransport::receive_data(someip_socket_t socket_fd, std::vector<uint8_t>& data) {
     // Respect maximum receive buffer size from config
     size_t max_chunk_size = std::min(static_cast<size_t>(4096), config_.max_receive_buffer - data.size());
     if (max_chunk_size == 0) {

--- a/src/transport/udp_transport.cpp
+++ b/src/transport/udp_transport.cpp
@@ -108,7 +108,7 @@ Result UdpTransport::disconnect() {
 }
 
 bool UdpTransport::is_connected() const {
-    return is_running() && socket_fd_ >= 0;
+    return is_running() && socket_fd_ != SOMEIP_INVALID_SOCKET;
 }
 
 Endpoint UdpTransport::get_local_endpoint() const {
@@ -133,7 +133,7 @@ Result UdpTransport::start() {
     result = bind_socket();
     if (result != Result::SUCCESS) {
         someip_close_socket(socket_fd_);
-        socket_fd_ = -1;
+        socket_fd_ = SOMEIP_INVALID_SOCKET;
         return result;
     }
 
@@ -153,10 +153,10 @@ Result UdpTransport::stop() {
     running_ = false;
 
     // Close socket to wake up receive thread
-    if (socket_fd_ >= 0) {
+    if (socket_fd_ != SOMEIP_INVALID_SOCKET) {
         someip_shutdown_socket(socket_fd_);
         someip_close_socket(socket_fd_);
-        socket_fd_ = -1;
+        socket_fd_ = SOMEIP_INVALID_SOCKET;
     }
 
     // Wait for receive thread to finish
@@ -175,7 +175,7 @@ bool UdpTransport::is_running() const {
 Result UdpTransport::join_multicast_group(const std::string& multicast_address) {
     platform::ScopedLock lock(socket_mutex_);
 
-    if (socket_fd_ < 0) {
+    if (socket_fd_ == SOMEIP_INVALID_SOCKET) {
         return Result::NOT_CONNECTED;
     }
 
@@ -221,7 +221,7 @@ Result UdpTransport::join_multicast_group(const std::string& multicast_address) 
 Result UdpTransport::leave_multicast_group(const std::string& multicast_address) {
     platform::ScopedLock lock(socket_mutex_);
 
-    if (socket_fd_ < 0) {
+    if (socket_fd_ == SOMEIP_INVALID_SOCKET) {
         return Result::NOT_CONNECTED;
     }
 
@@ -244,7 +244,7 @@ Result UdpTransport::create_socket() {
     platform::ScopedLock lock(socket_mutex_);
 
     socket_fd_ = socket(AF_INET, SOCK_DGRAM, 0);
-    if (socket_fd_ < 0) {
+    if (socket_fd_ == SOMEIP_INVALID_SOCKET) {
         return Result::NETWORK_ERROR;
     }
 
@@ -253,7 +253,7 @@ Result UdpTransport::create_socket() {
         int reuse = 1;
         if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
             someip_close_socket(socket_fd_);
-            socket_fd_ = -1;
+            socket_fd_ = SOMEIP_INVALID_SOCKET;
             return Result::NETWORK_ERROR;
         }
     }
@@ -273,7 +273,7 @@ Result UdpTransport::create_socket() {
         int broadcast = 1;
         if (someip_setsockopt(socket_fd_, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) < 0) {
             someip_close_socket(socket_fd_);
-            socket_fd_ = -1;
+            socket_fd_ = SOMEIP_INVALID_SOCKET;
             return Result::NETWORK_ERROR;
         }
     }
@@ -293,7 +293,7 @@ Result UdpTransport::create_socket() {
     if (!config_.blocking) {
         if (someip_set_nonblocking(socket_fd_) < 0) {
             someip_close_socket(socket_fd_);
-            socket_fd_ = -1;
+            socket_fd_ = SOMEIP_INVALID_SOCKET;
             return Result::NETWORK_ERROR;
         }
     }
@@ -391,7 +391,7 @@ void UdpTransport::receive_loop() {
 Result UdpTransport::send_data(const std::vector<uint8_t>& data, const Endpoint& endpoint) {
     platform::ScopedLock lock(socket_mutex_);
 
-    if (socket_fd_ < 0) {
+    if (socket_fd_ == SOMEIP_INVALID_SOCKET) {
         return Result::NOT_CONNECTED;
     }
 

--- a/tests/mocks/freertos/net_impl.h
+++ b/tests/mocks/freertos/net_impl.h
@@ -6,6 +6,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
 inline int someip_close_socket(int fd) { return close(fd); }
 inline void someip_shutdown_socket(int fd) { shutdown(fd, SHUT_RDWR); }
 inline int someip_set_nonblocking(int fd) {

--- a/tests/mocks/threadx/net_impl.h
+++ b/tests/mocks/threadx/net_impl.h
@@ -6,6 +6,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
 inline int someip_close_socket(int fd) { return close(fd); }
 inline void someip_shutdown_socket(int fd) { shutdown(fd, SHUT_RDWR); }
 inline int someip_set_nonblocking(int fd) {

--- a/tests/mocks/zephyr/net_impl.h
+++ b/tests/mocks/zephyr/net_impl.h
@@ -13,6 +13,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+using someip_socket_t = int;
+#define SOMEIP_INVALID_SOCKET (-1)
+
 inline int someip_close_socket(int fd) { return close(fd); }
 
 inline int someip_shutdown_socket(int fd) { return shutdown(fd, SHUT_RDWR); }


### PR DESCRIPTION
## Summary
- Introduce `someip_socket_t` type alias: `SOCKET` on Windows, `int` on POSIX/RTOS
- Introduce `SOMEIP_INVALID_SOCKET` constant: `INVALID_SOCKET` on Windows, `-1` elsewhere
- Update all platform `net_impl.h` files (win32, posix, zephyr, lwip, test mocks)
- Update transport headers and implementations to use `someip_socket_t` instead of raw `int` for socket handles
- Prevents silent 64-bit to 32-bit truncation of Winsock socket handles on 64-bit Windows

## Test plan
- [x] POSIX host build succeeds (verified)
- [x] All existing tests pass
- [x] Socket comparison logic uses `SOMEIP_INVALID_SOCKET` instead of `-1` / `< 0`

Closes #75

Made with [Cursor](https://cursor.com)