### PR TITLE
ci: separate coverage PR comment into its own job

### DIFF
--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -74,9 +74,10 @@ jobs:
     needs: build
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install coverage tools
         run: |
@@ -140,9 +141,29 @@ jobs:
           output: both
           fail_below_min: false
 
+      - name: Upload coverage summary
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-summary
+          path: code-coverage-results.md
+          retention-days: 14
+
+  coverage-comment:
+    name: Post Coverage PR Comment
+    runs-on: ubuntu-latest
+    needs: coverage
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download coverage summary
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
-        if: github.event_name == 'pull_request'
         with:
           header: coverage
           path: code-coverage-results.md


### PR DESCRIPTION
## Summary
- Remove `pull-requests: write` from the `coverage` job permissions
- Add `persist-credentials: false` to the checkout step
- Upload coverage summary markdown as an artifact
- Create new `coverage-comment` job with only `pull-requests: write` that downloads the summary and posts the PR comment
- Follows least-privilege principle, matching the `publish-test-results` pattern

## Test plan
- [x] Coverage job still generates reports correctly
- [x] Coverage summary uploaded as artifact
- [ ] New coverage-comment job posts PR comment on pull requests
- [x] Coverage comment only runs on pull_request events

Closes #58

Made with [Cursor](https://cursor.com)