### PR TITLE
ci: add coverage collection for RTOS test workflows

### DIFF
--- a/.github/workflows/freertos.yml
+++ b/.github/workflows/freertos.yml
@@ -62,6 +62,52 @@ jobs:
           path: build_freertos_rt/junit_results.xml
           retention-days: 14
 
+  coverage:
+    name: FreeRTOS coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install coverage tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcovr
+
+      - name: Build with coverage
+        run: |
+          cmake -B build_freertos_cov \
+            -DSOMEIP_FREERTOS_LINUX_TESTS=ON \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -ftest-coverage" \
+            -DCMAKE_C_FLAGS="--coverage -fprofile-arcs -ftest-coverage" \
+            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+            -S ${{ github.workspace }}
+          cmake --build build_freertos_cov
+
+      - name: Run tests
+        working-directory: build_freertos_cov
+        run: ctest --output-on-failure --timeout 30 --no-tests=error
+
+      - name: Generate coverage report
+        run: |
+          gcovr --root . \
+            --filter 'src/' \
+            --filter 'include/' \
+            --exclude '.*test.*' \
+            --exclude '.*example.*' \
+            --xml coverage-freertos.xml \
+            --print-summary
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-freertos
+          path: coverage-freertos.xml
+          retention-days: 14
+
   publish-test-results:
     name: Publish Test Results
     runs-on: ubuntu-latest

--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -62,6 +62,52 @@ jobs:
           path: build_threadx_rt/junit_results.xml
           retention-days: 14
 
+  coverage:
+    name: ThreadX coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install coverage tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcovr
+
+      - name: Build with coverage
+        run: |
+          cmake -B build_threadx_cov \
+            -DSOMEIP_THREADX_LINUX_TESTS=ON \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -ftest-coverage" \
+            -DCMAKE_C_FLAGS="--coverage -fprofile-arcs -ftest-coverage" \
+            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+            -S ${{ github.workspace }}
+          cmake --build build_threadx_cov
+
+      - name: Run tests
+        working-directory: build_threadx_cov
+        run: ctest --output-on-failure --timeout 30 --no-tests=error
+
+      - name: Generate coverage report
+        run: |
+          gcovr --root . \
+            --filter 'src/' \
+            --filter 'include/' \
+            --exclude '.*test.*' \
+            --exclude '.*example.*' \
+            --xml coverage-threadx.xml \
+            --print-summary
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-threadx
+          path: coverage-threadx.xml
+          retention-days: 14
+
   publish-test-results:
     name: Publish Test Results
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `coverage` job to `threadx.yml` and `freertos.yml` workflows
- Build with `--coverage -fprofile-arcs -ftest-coverage` in Debug mode
- Generate coverage XML reports via gcovr after test execution
- Upload coverage reports as artifacts (coverage-threadx, coverage-freertos)

## Test plan
- [x] Coverage jobs build with correct flags
- [x] gcovr generates XML reports filtering src/ and include/
- [x] Reports uploaded as artifacts
- [ ] Coverage data accurately reflects RTOS platform code paths

Closes #53

Made with [Cursor](https://cursor.com)