### PR TITLE
fix(ci): pin Zephyr to v4.3.0 to fix SDK 0.17.0 incompatibility

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Init Zephyr
         run: |
           python3.12 -m pip install jsonschema west
-          west init /tmp/zp && cd /tmp/zp
+          west init --mr v4.3.0 /tmp/zp && cd /tmp/zp
           west update --narrow -o=--depth=1 && west zephyr-export
           python3.12 -m pip install -r /tmp/zp/zephyr/scripts/requirements.txt
       - name: Build & run test_core
@@ -138,7 +138,7 @@ jobs:
       - name: Init Zephyr
         run: |
           python3.12 -m pip install jsonschema west
-          west init /tmp/zp && cd /tmp/zp
+          west init --mr v4.3.0 /tmp/zp && cd /tmp/zp
           west update --narrow -o=--depth=1 && west zephyr-export
           python3.12 -m pip install -r /tmp/zp/zephyr/scripts/requirements.txt
       - name: Build hello_s32k (mr_canhubk3)


### PR DESCRIPTION
## Summary

- **Pin `west init` to `--mr v4.3.0`** in both `zephyr-native-sim` and `zephyr-s32k344-build` jobs to avoid pulling Zephyr `main` (v4.3.99-dev), which requires SDK >= 1.0 and is incompatible with the installed SDK 0.17.0.
- This is the root cause of both Zephyr CI jobs failing on `main`.

## Root cause

`west init` without `--mr` defaults to pulling the latest `main` branch of the Zephyr repository. The Zephyr `main` branch recently bumped its minimum SDK requirement to `>= 1.0`, causing CMake configuration to fail:

```
Could not find a configuration file for package "Zephyr-sdk" that is
compatible with requested version "1.0".
```

SDK 0.17.x is guaranteed compatible with Zephyr 4.2.x and 4.3.x (per the [official compatibility matrix](https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-Version-Compatibility)).

## Test plan

- [ ] Verify `zephyr-native-sim` job passes (builds and runs test_core, test_transport, someip_echo, someip_sd_client)
- [ ] Verify `zephyr-s32k344-build` job passes (cross-compiles hello_s32k for mr_canhubk3)

Closes #97

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build initialization workflows to enforce consistent version targeting across build environments, improving build reproducibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->