### PR TITLE
fix(docs): guard SEO template against null page object

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,10 +3,10 @@
 {% block extrahead %}
   {{ super() }}
 
-  {% set page_title = page.title | default(config.site_name, true) %}
-  {% set page_desc = page.meta.description | default(config.site_description, true) %}
-  {% set page_url = page.canonical_url | default(config.site_url, true) %}
-  {% set raw_image = page.meta.image | default("images/social-card.png", true) %}
+  {% set page_title = (page.title if page else none) | default(config.site_name, true) %}
+  {% set page_desc = (page.meta.description if page and page.meta else none) | default(config.site_description, true) %}
+  {% set page_url = (page.canonical_url if page else none) | default(config.site_url, true) %}
+  {% set raw_image = (page.meta.image if page and page.meta else none) | default("images/social-card.png", true) %}
   {% if "://" in raw_image %}
     {% set page_image = raw_image %}
   {% else %}


### PR DESCRIPTION
The 404 template extends main.html but renders without a page object, causing page.meta.description to fail with UndefinedError. Add null checks so the template falls back to site-level defaults when page is None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved metadata handling in documentation templates to reliably resolve page information (title, description, image, URL) even when data is missing or undefined. Enhanced fallback mechanisms ensure consistent documentation display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->