### PR TITLE
ci: add detailed per-test reports using dorny/test-reporter

### DIFF
--- a/.github/workflows/freertos.yml
+++ b/.github/workflows/freertos.yml
@@ -225,7 +225,7 @@ jobs:
           comment_mode: "off"
 
       - name: Detailed Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "FreeRTOS Test Report"
           path: "**/*junit*.xml"

--- a/.github/workflows/host.yml
+++ b/.github/workflows/host.yml
@@ -240,7 +240,7 @@ jobs:
           comment_mode: "off"
 
       - name: Detailed Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "Host Test Report"
           path: "**/junit_results.xml"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,7 +90,7 @@ jobs:
           fail_on: "nothing"
 
       - name: Detailed Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "Python Test Report"
           path: "**/*junit*.xml"

--- a/.github/workflows/threadx.yml
+++ b/.github/workflows/threadx.yml
@@ -225,7 +225,7 @@ jobs:
           comment_mode: "off"
 
       - name: Detailed Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "ThreadX Test Report"
           path: "**/*junit*.xml"

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -230,7 +230,7 @@ jobs:
           comment_mode: "off"
 
       - name: Detailed Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "Zephyr Test Report"
           path: "**/*junit*.xml"


### PR DESCRIPTION
## Summary

- Add `dorny/test-reporter@v3` alongside existing `EnricoMi/publish-unit-test-result-action` in all 5 CI workflows (`host`, `freertos`, `threadx`, `zephyr`, `python-tests`)
- EnricoMi is kept for aggregate summaries; dorny/test-reporter provides per-test listings with individual test names, durations, and expandable stack traces on failures
- Python test report uses `fail-on-error: 'false'` to match existing `continue-on-error: true` behavior

## Configuration per workflow

| Workflow | Report Name | File Pattern | fail-on-error |
|----------|------------|--------------|---------------|
| host.yml | Host Test Report | `**/junit_results.xml` | default (true) |
| freertos.yml | FreeRTOS Test Report | `**/*junit*.xml` | default (true) |
| threadx.yml | ThreadX Test Report | `**/*junit*.xml` | default (true) |
| zephyr.yml | Zephyr Test Report | `**/*junit*.xml` | default (true) |
| python-tests.yml | Python Test Report | `**/*junit*.xml` | false |

Closes #115

## Test plan

- [ ] Verify all 5 CI workflows pass
- [ ] Confirm dorny/test-reporter check runs appear in the PR Checks tab with individual test listings
- [ ] Confirm EnricoMi aggregate summaries still appear as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD test reporting with detailed JUnit test result summaries and GitHub Actions integration across FreeRTOS, ThreadX, Zephyr, Python, and host build workflows.
  * Test results now include comprehensive test and suite listings in GitHub Actions summaries for improved visibility of build outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->