### PR TITLE
fix(tests): add null guards and clarifying comments

### DIFF
--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -328,6 +328,9 @@ TEST_F(E2ETest, CRC16_SingleByte) {
  * @test_case TC_E2E_CRC_005
  * @tests REQ_E2E_PLUGIN_004
  * @brief Each CRC type produces a non-zero result for a known payload
+ *
+ * The payload {0xDE, 0xAD, 0xBE, 0xEF} was verified to produce non-zero
+ * results for all three CRC algorithms (SAE-J1850, ITU-T X.25, CRC-32).
  */
 TEST_F(E2ETest, CRC_AllTypesNonZeroForKnownPayload) {
     std::vector<uint8_t> data = {0xDE, 0xAD, 0xBE, 0xEF};

--- a/tests/test_session_manager.cpp
+++ b/tests/test_session_manager.cpp
@@ -187,6 +187,7 @@ TEST_F(SessionManagerTest, ValidateSession_ErrorState) {
     uint16_t session_id = session_mgr_->create_session(0x1001);
 
     auto session = session_mgr_->get_session(session_id);
+    ASSERT_NE(session, nullptr);
     session->state = SessionState::ERROR;
     EXPECT_FALSE(session_mgr_->validate_session(session_id));
 }
@@ -199,6 +200,7 @@ TEST_F(SessionManagerTest, ValidateSession_ErrorState) {
 TEST_F(SessionManagerTest, UpdateActivity) {
     uint16_t session_id = session_mgr_->create_session(0x1001);
     auto session = session_mgr_->get_session(session_id);
+    ASSERT_NE(session, nullptr);
     auto original_time = session->last_activity;
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -299,6 +301,7 @@ TEST_F(SessionManagerTest, SessionCount_ExcludesNonActive) {
     EXPECT_EQ(session_mgr_->get_active_session_count(), 2u);
 
     auto session = session_mgr_->get_session(s1);
+    ASSERT_NE(session, nullptr);
     session->state = SessionState::INACTIVE;
 
     EXPECT_EQ(session_mgr_->get_active_session_count(), 1u);


### PR DESCRIPTION
## Summary
- Add clarifying comment to `CRC_AllTypesNonZeroForKnownPayload` test explaining the choice of `{0xDE, 0xAD, 0xBE, 0xEF}` payload (verified to produce non-zero results for all three CRC algorithms).
- Add `ASSERT_NE(session, nullptr)` guards in `ValidateSession_ErrorState`, `UpdateActivity`, and `SessionCount_ExcludesNonActive` tests before dereferencing `get_session()` return values, ensuring clean test failures instead of segfaults.

Closes #123

## Test plan
- [x] All 15 host test suites pass locally
- [x] CI checks pass across all platforms

Made with [Cursor](https://cursor.com)