### PR TITLE
refactor(build): consolidate libraries into single libopensomeip target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ endif()
 ################################################################################
 
 install(DIRECTORY include/ DESTINATION include/someip FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/ DESTINATION lib FILES_MATCHING PATTERN "libsomeip*")
+install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/ DESTINATION lib FILES_MATCHING PATTERN "libopensomeip*")
 
 ################################################################################
 # Configure Summary

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -132,17 +132,19 @@ The build system selects the correct PAL backend via include-path switching. Eac
 | `zephyr` | Zephyr `k_thread`, `k_mutex` | Zephyr sockets | Zephyr module build |
 | `lwip` | -- | lwIP sockets | `SOMEIP_USE_LWIP=ON` |
 
-## Library Targets
+## Library Target
+
+All SOME/IP sources are built as a single static library. Consumers link one target:
+
+```cmake
+target_link_libraries(my_app opensomeip)
+```
 
 | Target | Description |
 |--------|-------------|
-| `someip-core` | Core protocol + E2E protection |
-| `someip-transport` | UDP and TCP transport |
-| `someip-sd` | Service Discovery |
-| `someip-rpc` | RPC client/server |
-| `someip-events` | Event publisher/subscriber |
-| `someip-tp` | SOME/IP-TP segmentation/reassembly |
-| `someip-serialization` | Payload serialization |
+| `opensomeip` | Complete SOME/IP stack (core, transport, SD, RPC, events, TP, E2E, serialization) |
+
+For backward compatibility the legacy per-component names (`someip-core`, `someip-transport`, `someip-rpc`, `someip-sd`, `someip-events`, `someip-tp`, `someip-serialization`, `someip-e2e`, `someip-common`) are kept as CMake ALIAS targets that resolve to `opensomeip`. Dead code is eliminated by the linker via `--gc-sections`.
 
 ## Dependencies
 

--- a/docs/cross-compilation.md
+++ b/docs/cross-compilation.md
@@ -85,7 +85,7 @@ cmake --preset freertos-cortexm4
 cmake --build --preset freertos-cortexm4
 ```
 
-This produces `someip-core.a` (and other library targets) compiled for ARM Cortex-M4 with FreeRTOS threading and lwIP networking.
+This produces `libopensomeip.a` compiled for ARM Cortex-M4 with FreeRTOS threading and lwIP networking.
 
 ### Customizing for a different Cortex-M variant
 
@@ -130,7 +130,7 @@ Your board support package (BSP) must still provide:
 Link the SOME/IP libraries into your firmware:
 
 ```cmake
-target_link_libraries(my_firmware PRIVATE someip-core someip-transport someip-sd)
+target_link_libraries(my_firmware PRIVATE opensomeip)
 ```
 
 ### Testing without hardware

--- a/examples/advanced/complex_types/CMakeLists.txt
+++ b/examples/advanced/complex_types/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Server executable
 add_executable(complex_types_server server.cpp)
-target_link_libraries(complex_types_server someip-rpc)
+target_link_libraries(complex_types_server opensomeip)
 target_include_directories(complex_types_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Client executable
 add_executable(complex_types_client client.cpp)
-target_link_libraries(complex_types_client someip-rpc)
+target_link_libraries(complex_types_client opensomeip)
 target_include_directories(complex_types_client PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 

--- a/examples/advanced/large_messages/CMakeLists.txt
+++ b/examples/advanced/large_messages/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Server executable
 add_executable(large_messages_server server.cpp)
-target_link_libraries(large_messages_server someip-rpc someip-tp)
+target_link_libraries(large_messages_server opensomeip)
 target_include_directories(large_messages_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Client executable
 add_executable(large_messages_client client.cpp)
-target_link_libraries(large_messages_client someip-rpc someip-tp)
+target_link_libraries(large_messages_client opensomeip)
 target_include_directories(large_messages_client PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 

--- a/examples/advanced/multi_service/CMakeLists.txt
+++ b/examples/advanced/multi_service/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Server executable
 add_executable(multi_service_server server.cpp)
-target_link_libraries(multi_service_server someip-events)
+target_link_libraries(multi_service_server opensomeip)
 target_include_directories(multi_service_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Client executable
 add_executable(multi_service_client client.cpp)
-target_link_libraries(multi_service_client someip-rpc)
+target_link_libraries(multi_service_client opensomeip)
 target_include_directories(multi_service_client PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 

--- a/examples/advanced/udp_config/CMakeLists.txt
+++ b/examples/advanced/udp_config/CMakeLists.txt
@@ -1,3 +1,3 @@
 # UDP Configuration Example
 add_executable(udp_config_example udp_config_example.cpp)
-target_link_libraries(udp_config_example someip-transport someip-core)
+target_link_libraries(udp_config_example opensomeip)

--- a/examples/basic/events/CMakeLists.txt
+++ b/examples/basic/events/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Publisher executable
 add_executable(events_publisher publisher.cpp)
-target_link_libraries(events_publisher someip-events)
+target_link_libraries(events_publisher opensomeip)
 target_include_directories(events_publisher PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Subscriber executable
 add_executable(events_subscriber subscriber.cpp)
-target_link_libraries(events_subscriber someip-events)
+target_link_libraries(events_subscriber opensomeip)
 target_include_directories(events_subscriber PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Custom targets for convenience

--- a/examples/basic/hello_world/CMakeLists.txt
+++ b/examples/basic/hello_world/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Server executable
 add_executable(hello_world_server server.cpp)
-target_link_libraries(hello_world_server someip-transport)
+target_link_libraries(hello_world_server opensomeip)
 target_include_directories(hello_world_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Client executable
 add_executable(hello_world_client client.cpp)
-target_link_libraries(hello_world_client someip-transport)
+target_link_libraries(hello_world_client opensomeip)
 target_include_directories(hello_world_client PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 

--- a/examples/basic/method_calls/CMakeLists.txt
+++ b/examples/basic/method_calls/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Server executable
 add_executable(method_calls_server server.cpp)
-target_link_libraries(method_calls_server someip-rpc)
+target_link_libraries(method_calls_server opensomeip)
 target_include_directories(method_calls_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Client executable
 add_executable(method_calls_client client.cpp)
-target_link_libraries(method_calls_client someip-rpc)
+target_link_libraries(method_calls_client opensomeip)
 target_include_directories(method_calls_client PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 

--- a/examples/basic/sd_demo/CMakeLists.txt
+++ b/examples/basic/sd_demo/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(sd_demo_server server.cpp)
-target_link_libraries(sd_demo_server someip-sd someip-transport)
+target_link_libraries(sd_demo_server opensomeip)
 target_include_directories(sd_demo_server PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/examples/e2e_protection/CMakeLists.txt
+++ b/examples/e2e_protection/CMakeLists.txt
@@ -2,12 +2,12 @@
 
 # Basic E2E protection example
 add_executable(basic_e2e basic_e2e.cpp)
-target_link_libraries(basic_e2e someip-core)
+target_link_libraries(basic_e2e opensomeip)
 
 # Plugin integration example
 add_executable(plugin_integration plugin_integration.cpp)
-target_link_libraries(plugin_integration someip-core)
+target_link_libraries(plugin_integration opensomeip)
 
 # Safety-critical example
 add_executable(safety_critical safety_critical.cpp)
-target_link_libraries(safety_critical someip-core)
+target_link_libraries(safety_critical opensomeip)

--- a/examples/renode/freertos_multitask/CMakeLists.txt
+++ b/examples/renode/freertos_multitask/CMakeLists.txt
@@ -21,8 +21,7 @@ if(SOMEIP_FREERTOS_RENODE_TESTS)
     )
 
     target_link_libraries(freertos_multitask_demo PRIVATE
-        someip-core
-        someip-serialization
+        opensomeip
         stm32f407_bsp
     )
 

--- a/examples/renode/threadx_pool_demo/CMakeLists.txt
+++ b/examples/renode/threadx_pool_demo/CMakeLists.txt
@@ -20,8 +20,7 @@ if(SOMEIP_THREADX_RENODE_TESTS)
     )
     target_compile_definitions(threadx_pool_demo PRIVATE TX_INCLUDE_USER_DEFINE_FILE)
     target_link_libraries(threadx_pool_demo PRIVATE
-        someip-core
-        someip-serialization
+        opensomeip
         stm32f407_bsp
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,30 +1,30 @@
-# Core library sources
-set(CORE_SOURCES
+# All library sources consolidated into a single target.
+# Linker --gc-sections handles dead code elimination for consumers that only
+# use a subset of the stack (~570K total, 30 object files).
+set(OPENSOMEIP_SOURCES
     common/result.cpp
     someip/types.cpp
     someip/message.cpp
     core/session_manager.cpp
-)
-
-# Serialization library sources
-set(SERIALIZATION_SOURCES
     serialization/serializer.cpp
-)
-
-# Transport library sources
-set(TRANSPORT_SOURCES
     transport/endpoint.cpp
     transport/udp_transport.cpp
     transport/tcp_transport.cpp
-)
-
-# E2E library sources (defined before core since core depends on E2E header)
-set(E2E_SOURCES
     e2e/e2e_protection.cpp
     e2e/e2e_header.cpp
     e2e/e2e_crc.cpp
     e2e/e2e_profile_registry.cpp
     e2e/e2e_profiles/standard_profile.cpp
+    rpc/rpc_client.cpp
+    rpc/rpc_server.cpp
+    sd/sd_message.cpp
+    sd/sd_client.cpp
+    sd/sd_server.cpp
+    events/event_publisher.cpp
+    events/event_subscriber.cpp
+    tp/tp_segmenter.cpp
+    tp/tp_reassembler.cpp
+    tp/tp_manager.cpp
 )
 
 # --- Platform backend selection via include path ---
@@ -48,154 +48,66 @@ else()
     set(SOMEIP_NET_IMPL_DIR ${PROJECT_SOURCE_DIR}/include/platform/posix)
 endif()
 
-# Use OBJECT libraries to avoid circular dependency between core and E2E
-# Both are compiled separately but linked together
-
-# Core object library
-add_library(someip-core-obj OBJECT ${CORE_SOURCES})
-target_include_directories(someip-core-obj PUBLIC
+# Single consolidated library target
+add_library(opensomeip STATIC ${OPENSOMEIP_SOURCES})
+target_include_directories(opensomeip PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${SOMEIP_THREADING_IMPL_DIR}
     ${SOMEIP_NET_IMPL_DIR}
 )
 
-# E2E object library
-add_library(someip-e2e-obj OBJECT ${E2E_SOURCES})
-target_include_directories(someip-e2e-obj PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
-    ${SOMEIP_THREADING_IMPL_DIR}
-    ${SOMEIP_NET_IMPL_DIR}
-)
-
-# Create combined core library that includes both core and E2E objects
-add_library(someip-core STATIC
-    $<TARGET_OBJECTS:someip-core-obj>
-    $<TARGET_OBJECTS:someip-e2e-obj>
-)
-target_include_directories(someip-core PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
-    ${SOMEIP_THREADING_IMPL_DIR}
-    ${SOMEIP_NET_IMPL_DIR}
-)
-
-# Threading library: only link pthreads on non-RTOS builds
+# Threading: only link pthreads on non-RTOS builds
 if(NOT SOMEIP_USE_FREERTOS AND NOT SOMEIP_USE_THREADX)
     find_package(Threads REQUIRED)
-    target_link_libraries(someip-core PUBLIC Threads::Threads)
+    target_link_libraries(opensomeip PUBLIC Threads::Threads)
 endif()
 
-# RTOS kernel linkage: propagate include dirs to OBJECT libraries so
-# FreeRTOS.h/tx_api.h and their port headers are found during compilation.
+# RTOS kernel linkage
 if(SOMEIP_USE_FREERTOS AND TARGET freertos_kernel)
-    target_link_libraries(someip-core-obj PUBLIC freertos_kernel)
-    target_link_libraries(someip-e2e-obj PUBLIC freertos_kernel)
-    target_link_libraries(someip-core PUBLIC freertos_kernel)
+    target_link_libraries(opensomeip PUBLIC freertos_kernel)
 endif()
 if(SOMEIP_USE_THREADX AND TARGET threadx)
-    target_link_libraries(someip-core-obj PUBLIC threadx)
-    target_link_libraries(someip-e2e-obj PUBLIC threadx)
-    target_link_libraries(someip-core PUBLIC threadx)
+    target_link_libraries(opensomeip PUBLIC threadx)
 endif()
 
 if(WIN32)
-    target_link_libraries(someip-core PUBLIC ws2_32)
+    target_link_libraries(opensomeip PUBLIC ws2_32)
 endif()
 
 # FreeRTOS platform sources
 if(SOMEIP_USE_FREERTOS)
-    target_sources(someip-core PRIVATE
+    target_sources(opensomeip PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/freertos/memory.cpp)
 endif()
 
 # ThreadX platform sources
 if(SOMEIP_USE_THREADX)
-    target_sources(someip-core PRIVATE
+    target_sources(opensomeip PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/threadx/memory.cpp)
 endif()
 
-# Create E2E library as an alias to core (for backward compatibility)
-add_library(someip-e2e ALIAS someip-core)
-
-# Create serialization library (depends on core)
-add_library(someip-serialization STATIC ${SERIALIZATION_SOURCES})
-target_include_directories(someip-serialization PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(someip-serialization PUBLIC someip-core)
-
-# RPC library sources
-set(RPC_SOURCES
-    rpc/rpc_client.cpp
-    rpc/rpc_server.cpp
-)
-
-# SD library sources
-set(SD_SOURCES
-    sd/sd_message.cpp
-    sd/sd_client.cpp
-    sd/sd_server.cpp
-)
-
-# Events library sources
-set(EVENTS_SOURCES
-    events/event_publisher.cpp
-    events/event_subscriber.cpp
-)
-
-# TP library sources
-set(TP_SOURCES
-    tp/tp_segmenter.cpp
-    tp/tp_reassembler.cpp
-    tp/tp_manager.cpp
-)
-
-# Create transport library (depends on core + threading)
-add_library(someip-transport STATIC ${TRANSPORT_SOURCES})
-target_include_directories(someip-transport PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
-    ${SOMEIP_THREADING_IMPL_DIR}
-    ${SOMEIP_NET_IMPL_DIR}
-)
-if(NOT SOMEIP_USE_FREERTOS AND NOT SOMEIP_USE_THREADX)
-    target_link_libraries(someip-transport PRIVATE someip-core PRIVATE Threads::Threads)
-else()
-    target_link_libraries(someip-transport PRIVATE someip-core)
-endif()
-
-# Create RPC library (depends on core, transport, serialization)
-add_library(someip-rpc STATIC ${RPC_SOURCES})
-target_include_directories(someip-rpc PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(someip-rpc PRIVATE someip-core PRIVATE someip-transport PRIVATE someip-serialization)
-
-# Create SD library (depends on core, transport)
-add_library(someip-sd STATIC ${SD_SOURCES})
-target_include_directories(someip-sd PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(someip-sd PRIVATE someip-core PRIVATE someip-transport)
-
-# Create Events library (depends on core, transport, rpc)
-add_library(someip-events STATIC ${EVENTS_SOURCES})
-target_include_directories(someip-events PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(someip-events PRIVATE someip-core PRIVATE someip-transport PRIVATE someip-rpc)
-
-# Create TP library (depends on core, transport)
-add_library(someip-tp STATIC ${TP_SOURCES})
-target_include_directories(someip-tp PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(someip-tp PRIVATE someip-core PRIVATE someip-transport)
-
-# Create convenience aliases for backward compatibility
-add_library(someip-common ALIAS someip-core)
+# Backward-compatible aliases so existing target_link_libraries() calls
+# continue to work (e.g. target_link_libraries(my_app someip-rpc)).
+add_library(someip-core ALIAS opensomeip)
+add_library(someip-transport ALIAS opensomeip)
+add_library(someip-rpc ALIAS opensomeip)
+add_library(someip-sd ALIAS opensomeip)
+add_library(someip-events ALIAS opensomeip)
+add_library(someip-tp ALIAS opensomeip)
+add_library(someip-serialization ALIAS opensomeip)
+add_library(someip-e2e ALIAS opensomeip)
+add_library(someip-common ALIAS opensomeip)
 
 # Windows portability: suppress problematic macros from <windows.h>.
 #   NOGDI            – prevents <wingdi.h> (defines ERROR as 0)
 #   WIN32_LEAN_AND_MEAN – trims unused Win32 sub-headers
 #   NOMINMAX         – prevents min/max macros that break std::min/std::max
 if(WIN32)
-    foreach(_tgt someip-core-obj someip-e2e-obj someip-serialization
-                 someip-transport someip-rpc someip-sd someip-events someip-tp)
-        target_compile_definitions(${_tgt} PRIVATE NOGDI WIN32_LEAN_AND_MEAN NOMINMAX)
-    endforeach()
+    target_compile_definitions(opensomeip PRIVATE NOGDI WIN32_LEAN_AND_MEAN NOMINMAX)
 endif()
 
-# Set library properties (only on real targets, not aliases)
-set_target_properties(someip-core someip-serialization someip-transport PROPERTIES
+# Set library properties
+set_target_properties(opensomeip PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
 )


### PR DESCRIPTION
## Summary

Consolidates the 7 separate static libraries into a single `opensomeip` target, as proposed in #96.

- **`src/CMakeLists.txt`**: Merged all source lists (`CORE_SOURCES`, `SERIALIZATION_SOURCES`, `TRANSPORT_SOURCES`, `E2E_SOURCES`, `RPC_SOURCES`, `SD_SOURCES`, `EVENTS_SOURCES`, `TP_SOURCES`) into a single `OPENSOMEIP_SOURCES` list and a single `opensomeip` STATIC target. All backward-compatible ALIAS targets (`someip-core`, `someip-transport`, `someip-rpc`, `someip-sd`, `someip-events`, `someip-tp`, `someip-serialization`, `someip-e2e`, `someip-common`) are preserved so existing consumers continue to work without changes.
- **`examples/**/CMakeLists.txt`**: Updated all in-repo examples to link `opensomeip` directly instead of individual component libraries.
- **`cmake/README.md`**, **`docs/cross-compilation.md`**: Updated library target documentation to reflect the single-target approach.
- **`CMakeLists.txt`**: Updated `install()` glob pattern from `libsomeip*` to `libopensomeip*`.

## Verification

- Clean build succeeds (host-macos-tests preset)
- All **15/15 host tests pass**
- Single `libopensomeip.a` (~589K) produced — no individual library artifacts
- Backward-compatible aliases resolve correctly (tests use `someip-core`, `someip-transport`, etc. through aliases)
- Zephyr module build is unaffected (uses its own `zephyr_library_named` target)

## Test plan

- [x] Clean build with `cmake --preset host-macos-tests` succeeds
- [x] All 15 host tests pass via `ctest --preset host-macos-tests`
- [x] CI: host-linux build and tests pass
- [x] CI: FreeRTOS compile-check and linux-port tests pass
- [x] CI: ThreadX compile-check and linux-port tests pass
- [x] CI: Zephyr module build unaffected
- [x] CI: PAL conformance tests (freertos-mock, threadx-mock, zephyr-mock) pass

Closes #96

Made with [Cursor](https://cursor.com)