### PR TITLE
fix(ci): use recursive find for JUnit XML discovery in Python workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -69,9 +69,11 @@ jobs:
       - name: Set test suite names in JUnit XML
         run: |
           for dir in test-results-*/; do
-            suite=$(echo "$dir" | sed 's|^test-results-||;s|/$||')
-            for xml in "$dir"*.xml; do
-              [ -f "$xml" ] && sed -i "s/<testsuite name=\"pytest\"/<testsuite name=\"${suite}\"/" "$xml"
+            [ -d "$dir" ] || continue
+            suite="${dir#test-results-}"
+            suite="${suite%/}"
+            find "$dir" -type f -name '*.xml' -print0 | while IFS= read -r -d '' xml; do
+              sed -i "s/<testsuite name=\"pytest\"/<testsuite name=\"${suite}\"/" "$xml"
             done
           done
 


### PR DESCRIPTION
## Summary
- Replace the non-recursive glob in the "Set test suite names in JUnit XML" step with `find -print0` for recursive XML discovery
- Add directory validation (`[ -d "$dir" ] || continue`) before processing
- Use POSIX parameter expansion (`${dir#test-results-}`, `${suite%/}`) instead of `sed` for deriving the suite name
- Use null-delimited iteration (`read -r -d ''`) for safe filename handling

## Test plan
- [x] Python `publish-test-results` job still correctly renames test suites in JUnit XML
- [x] No regression in test report generation

Closes #131

Made with [Cursor](https://cursor.com)