### PR TITLE
fix: remediate batch 5 clang-tidy violations

### DIFF
--- a/include/platform/lwip/net_impl.h
+++ b/include/platform/lwip/net_impl.h
@@ -44,14 +44,18 @@ static inline int someip_shutdown_socket(someip_socket_t fd) {
 static inline int someip_set_nonblocking(someip_socket_t fd) {
     int flags = lwip_fcntl(fd, F_GETFL, 0);
     if (flags < 0) return -1;
-    return lwip_fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    return lwip_fcntl(fd, F_SETFL,
+                      static_cast<int>(static_cast<unsigned int>(flags) |
+                                       static_cast<unsigned int>(O_NONBLOCK)));
 }
 
 /** @implements REQ_PLATFORM_LWIP_001 */
 static inline int someip_set_blocking(someip_socket_t fd) {
     int flags = lwip_fcntl(fd, F_GETFL, 0);
     if (flags < 0) return -1;
-    return lwip_fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+    return lwip_fcntl(fd, F_SETFL,
+                      static_cast<int>(static_cast<unsigned int>(flags) &
+                                       ~static_cast<unsigned int>(O_NONBLOCK)));
 }
 
 /* ---------- Socket creation & connection ----------------------------------- */

--- a/include/platform/posix/net_impl.h
+++ b/include/platform/posix/net_impl.h
@@ -46,7 +46,9 @@ static inline int someip_set_nonblocking(someip_socket_t fd) {
     if (flags < 0) {
         return -1;
     }
-    return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    return fcntl(fd, F_SETFL,
+                 static_cast<int>(static_cast<unsigned int>(flags) |
+                                  static_cast<unsigned int>(O_NONBLOCK)));
 }
 
 /** @implements REQ_PAL_NET_BLOCK, REQ_PAL_NET_MODE_E01 */
@@ -55,7 +57,9 @@ static inline int someip_set_blocking(someip_socket_t fd) {
     if (flags < 0) {
         return -1;
     }
-    return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+    return fcntl(fd, F_SETFL,
+                 static_cast<int>(static_cast<unsigned int>(flags) &
+                                  ~static_cast<unsigned int>(O_NONBLOCK)));
 }
 
 /* ---------- Socket creation & connection ----------------------------------- */

--- a/include/platform/zephyr/net_impl.h
+++ b/include/platform/zephyr/net_impl.h
@@ -75,13 +75,17 @@ static inline int someip_shutdown_socket(someip_socket_t fd) {
 static inline int someip_set_nonblocking(someip_socket_t fd) {
     int flags = zsock_fcntl(fd, ZVFS_F_GETFL, 0);
     if (flags < 0) return -1;
-    return zsock_fcntl(fd, ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
+    return zsock_fcntl(fd, ZVFS_F_SETFL,
+                       static_cast<int>(static_cast<unsigned int>(flags) |
+                                        static_cast<unsigned int>(ZVFS_O_NONBLOCK)));
 }
 
 static inline int someip_set_blocking(someip_socket_t fd) {
     int flags = zsock_fcntl(fd, ZVFS_F_GETFL, 0);
     if (flags < 0) return -1;
-    return zsock_fcntl(fd, ZVFS_F_SETFL, flags & ~ZVFS_O_NONBLOCK);
+    return zsock_fcntl(fd, ZVFS_F_SETFL,
+                       static_cast<int>(static_cast<unsigned int>(flags) &
+                                        ~static_cast<unsigned int>(ZVFS_O_NONBLOCK)));
 }
 
 /* ---------- Socket creation & connection ----------------------------------- */

--- a/include/sd/sd_message.h
+++ b/include/sd/sd_message.h
@@ -220,22 +220,22 @@ public:
     bool deserialize(const std::vector<uint8_t>& data);
 
     // Helper methods
-    bool is_reboot() const { return (flags_ & 0x80) != 0; }
-    bool is_unicast() const { return (flags_ & 0x40) != 0; }
+    bool is_reboot() const { return (static_cast<uint32_t>(flags_) & 0x80U) != 0; }
+    bool is_unicast() const { return (static_cast<uint32_t>(flags_) & 0x40U) != 0; }
 
     void set_reboot(bool reboot) {
         if (reboot) {
-            flags_ |= 0x80;
+            flags_ = static_cast<uint8_t>(static_cast<uint32_t>(flags_) | 0x80U);
         } else {
-            flags_ &= ~0x80;
+            flags_ = static_cast<uint8_t>(static_cast<uint32_t>(flags_) & ~0x80U);
         }
     }
 
     void set_unicast(bool unicast) {
         if (unicast) {
-            flags_ |= 0x40;
+            flags_ = static_cast<uint8_t>(static_cast<uint32_t>(flags_) | 0x40U);
         } else {
-            flags_ &= ~0x40;
+            flags_ = static_cast<uint8_t>(static_cast<uint32_t>(flags_) & ~0x40U);
         }
     }
 

--- a/include/someip/types.h
+++ b/include/someip/types.h
@@ -76,11 +76,11 @@ struct MessageId {
     MessageId(uint16_t service, uint16_t method) : service_id(service), method_id(method) {}
 
     uint32_t to_uint32() const {
-        return (static_cast<uint32_t>(service_id) << 16) | method_id;
+        return (static_cast<uint32_t>(service_id) << 16) | static_cast<uint32_t>(method_id);
     }
 
     static MessageId from_uint32(uint32_t value) {
-        return MessageId(static_cast<uint16_t>(value >> 16), static_cast<uint16_t>(value & 0xFFFF));
+        return MessageId(static_cast<uint16_t>(value >> 16), static_cast<uint16_t>(value & 0xFFFFU));
     }
 
     bool operator==(const MessageId& other) const {
@@ -103,11 +103,11 @@ struct RequestId {
     RequestId(uint16_t client, uint16_t session) : client_id(client), session_id(session) {}
 
     uint32_t to_uint32() const {
-        return (static_cast<uint32_t>(client_id) << 16) | session_id;
+        return (static_cast<uint32_t>(client_id) << 16) | static_cast<uint32_t>(session_id);
     }
 
     static RequestId from_uint32(uint32_t value) {
-        return RequestId(static_cast<uint16_t>(value >> 16), static_cast<uint16_t>(value & 0xFFFF));
+        return RequestId(static_cast<uint16_t>(value >> 16), static_cast<uint16_t>(value & 0xFFFFU));
     }
 
     bool operator==(const RequestId& other) const {

--- a/include/tp/tp_segmenter.h
+++ b/include/tp/tp_segmenter.h
@@ -78,7 +78,7 @@ private:
                                  const std::vector<uint8_t>& payload,
                                  std::vector<TpSegment>& segments);
 
-    void serialize_tp_header(std::vector<uint8_t>& payload, uint16_t offset, bool more_segments);
+    void serialize_tp_header(std::vector<uint8_t>& payload, uint32_t offset, bool more_segments);
     MessageType add_tp_flag(MessageType type) const;
 };
 

--- a/src/e2e/e2e_crc.cpp
+++ b/src/e2e/e2e_crc.cpp
@@ -34,20 +34,20 @@ static constexpr uint8_t SAE_J1850_INIT = 0xFF;
 
 /** @implements REQ_E2E_PLUGIN_004 */
 uint8_t calculate_crc8_sae_j1850(const std::vector<uint8_t>& data) {
-    uint8_t crc = SAE_J1850_INIT;
+    uint32_t crc_reg = SAE_J1850_INIT;
 
     for (uint8_t byte : data) {
-        crc ^= byte;
+        crc_reg ^= static_cast<uint32_t>(byte);
         for (int i = 0; i < 8; ++i) {
-            if ((crc & 0x80) != 0) {
-                crc = (crc << 1) ^ SAE_J1850_POLY;
+            if ((crc_reg & 0x80U) != 0) {
+                crc_reg = ((crc_reg << 1U) ^ static_cast<uint32_t>(SAE_J1850_POLY)) & 0xFFU;
             } else {
-                crc <<= 1;
+                crc_reg = (crc_reg << 1U) & 0xFFU;
             }
         }
     }
 
-    return crc;
+    return static_cast<uint8_t>(crc_reg);
 }
 
 // ITU-T X.25 / CCITT CRC-16 polynomial: 0x1021 (x^16 + x^12 + x^5 + 1)
@@ -55,20 +55,20 @@ static constexpr uint16_t ITU_X25_POLY = 0x1021;
 static constexpr uint16_t ITU_X25_INIT = 0xFFFF;
 
 uint16_t calculate_crc16_itu_x25(const std::vector<uint8_t>& data) {
-    uint16_t crc = ITU_X25_INIT;
+    uint32_t crc_reg = ITU_X25_INIT;
 
     for (uint8_t byte : data) {
-        crc ^= (static_cast<uint16_t>(byte) << 8);
+        crc_reg ^= static_cast<uint32_t>(byte) << 8U;
         for (int i = 0; i < 8; ++i) {
-            if ((crc & 0x8000) != 0) {
-                crc = (crc << 1) ^ ITU_X25_POLY;
+            if ((crc_reg & 0x8000U) != 0) {
+                crc_reg = ((crc_reg << 1U) ^ static_cast<uint32_t>(ITU_X25_POLY)) & 0xFFFFU;
             } else {
-                crc <<= 1;
+                crc_reg = (crc_reg << 1U) & 0xFFFFU;
             }
         }
     }
 
-    return crc;
+    return static_cast<uint16_t>(crc_reg);
 }
 
 // CRC-32 polynomial: 0x04C11DB7 (IEEE 802.3)
@@ -81,12 +81,12 @@ const std::array<uint32_t, 256>& get_crc32_table() {
     static const std::array<uint32_t, 256> table = [] {
         std::array<uint32_t, 256> t{};
         for (uint32_t i = 0; i < 256; ++i) {
-            uint32_t crc = i << 24;
+            uint32_t crc = i << 24U;
             for (int j = 0; j < 8; ++j) {
-                if (crc & 0x80000000) {
-                    crc = (crc << 1) ^ CRC32_POLY;
+                if (crc & 0x80000000U) {
+                    crc = (crc << 1U) ^ CRC32_POLY;
                 } else {
-                    crc <<= 1;
+                    crc <<= 1U;
                 }
             }
             t[i] = crc;
@@ -104,8 +104,8 @@ uint32_t calculate_crc32(const std::vector<uint8_t>& data) {
     uint32_t crc = CRC32_INIT;
 
     for (uint8_t byte : data) {
-        uint32_t index = ((crc >> 24) ^ byte) & 0xFF;
-        crc = (crc << 8) ^ crc32_table[index];
+        uint32_t index = ((crc >> 24U) ^ static_cast<uint32_t>(byte)) & 0xFFU;
+        crc = (crc << 8U) ^ crc32_table[index];
     }
 
     return crc;

--- a/src/e2e/e2e_profiles/standard_profile.cpp
+++ b/src/e2e/e2e_profiles/standard_profile.cpp
@@ -118,7 +118,7 @@ public:
          auto now = std::chrono::steady_clock::now();
          auto ms =
              std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-         freshness = static_cast<uint16_t>(ms & 0xFFFF);
+         freshness = static_cast<uint16_t>(static_cast<uint64_t>(ms) & 0xFFFFULL);
          freshness_values_[config.data_id] = freshness;
      }
 
@@ -185,11 +185,11 @@ public:
 
             uint32_t received_crc = header.crc;
             if (config.crc_type == 0) {  // 8-bit
-                received_crc &= 0xFF;
-                expected_crc &= 0xFF;
+                received_crc &= 0xFFU;
+                expected_crc &= 0xFFU;
             } else if (config.crc_type == 1) {  // 16-bit
-                received_crc &= 0xFFFF;
-                expected_crc &= 0xFFFF;
+                received_crc &= 0xFFFFU;
+                expected_crc &= 0xFFFFU;
             }
 
             if (received_crc != expected_crc) {
@@ -246,7 +246,7 @@ public:
             auto now = std::chrono::steady_clock::now();
             auto ms_now = std::chrono::duration_cast<std::chrono::milliseconds>(
                 now.time_since_epoch()).count();
-            auto current_freshness = static_cast<uint16_t>(ms_now & 0xFFFF);
+            auto current_freshness = static_cast<uint16_t>(static_cast<uint64_t>(ms_now) & 0xFFFFULL);
 
             // Calculate freshness difference (handle wrap-around)
             // Since we're using 16-bit values, we need to handle wrap-around
@@ -258,14 +258,15 @@ public:
                 freshness_diff = current_freshness - header.freshness_value;
             } else {
                 // Wrap-around case - calculate how much time passed
-                freshness_diff = (0xFFFF - header.freshness_value) + current_freshness + 1;
+                freshness_diff = static_cast<uint16_t>((0xFFFFU - static_cast<uint32_t>(header.freshness_value)) +
+                                                       static_cast<uint32_t>(current_freshness) + 1U);
             }
 
             // Convert timeout to 16-bit units (approximately)
             // Since we're storing lower 16 bits of milliseconds,
             // we compare against timeout_ms directly (assuming timeout < 65535 ms)
             auto const timeout_units = static_cast<uint16_t>(config.freshness_timeout_ms);
-            if (freshness_diff > timeout_units && freshness_diff < (0xFFFF - timeout_units)) {
+            if (freshness_diff > timeout_units && freshness_diff < (0xFFFFU - timeout_units)) {
                 // If difference is large and not due to wrap-around, it's stale
                 return Result::TIMEOUT;  // Stale data
             }

--- a/src/e2e/e2e_profiles/standard_profile.cpp
+++ b/src/e2e/e2e_profiles/standard_profile.cpp
@@ -265,7 +265,8 @@ public:
             // Convert timeout to 16-bit units (approximately)
             // Since we're storing lower 16 bits of milliseconds,
             // we compare against timeout_ms directly (assuming timeout < 65535 ms)
-            auto const timeout_units = static_cast<uint16_t>(config.freshness_timeout_ms);
+            auto const timeout_units = static_cast<uint16_t>(
+                config.freshness_timeout_ms > 0xFFFFU ? 0xFFFFU : config.freshness_timeout_ms);
             if (freshness_diff > timeout_units && freshness_diff < (0xFFFFU - timeout_units)) {
                 // If difference is large and not due to wrap-around, it's stale
                 return Result::TIMEOUT;  // Stale data

--- a/src/events/event_subscriber.cpp
+++ b/src/events/event_subscriber.cpp
@@ -34,7 +34,7 @@ namespace someip::events {
  */
 class EventSubscriberImpl : public transport::ITransportListener {
 public:
-    EventSubscriberImpl(uint16_t client_id)
+    explicit EventSubscriberImpl(uint16_t client_id)
         : client_id_(client_id),
           transport_(std::make_shared<transport::UdpTransport>(
               transport::Endpoint("127.0.0.1", 0))),
@@ -112,8 +112,8 @@ public:
 
         // Add subscription data to payload
         std::vector<uint8_t> payload;
-        payload.push_back((eventgroup_id >> 8) & 0xFF);
-        payload.push_back(eventgroup_id & 0xFF);
+        payload.push_back(static_cast<uint8_t>((static_cast<uint32_t>(eventgroup_id) >> 8U) & 0xFFU));
+        payload.push_back(static_cast<uint8_t>(static_cast<uint32_t>(eventgroup_id) & 0xFFU));
         subscription_msg.set_payload(payload);
 
         Result send_result = transport_->send_message(subscription_msg, service_endpoint);
@@ -146,8 +146,8 @@ public:
 
         // Add unsubscription data to payload
         std::vector<uint8_t> payload;
-        payload.push_back((eventgroup_id >> 8) & 0xFF);
-        payload.push_back(eventgroup_id & 0xFF);
+        payload.push_back(static_cast<uint8_t>((static_cast<uint32_t>(eventgroup_id) >> 8U) & 0xFFU));
+        payload.push_back(static_cast<uint8_t>(static_cast<uint32_t>(eventgroup_id) & 0xFFU));
         unsubscription_msg.set_payload(payload);
 
         Result result = transport_->send_message(unsubscription_msg, service_endpoint);
@@ -181,8 +181,8 @@ public:
 
         // Add field ID to payload
         std::vector<uint8_t> payload;
-        payload.push_back((event_id >> 8) & 0xFF);
-        payload.push_back(event_id & 0xFF);
+        payload.push_back(static_cast<uint8_t>((static_cast<uint32_t>(event_id) >> 8U) & 0xFFU));
+        payload.push_back(static_cast<uint8_t>(static_cast<uint32_t>(event_id) & 0xFFU));
         field_msg.set_payload(payload);
 
         return transport_->send_message(field_msg, service_endpoint) == Result::SUCCESS;

--- a/src/rpc/rpc_client.cpp
+++ b/src/rpc/rpc_client.cpp
@@ -37,7 +37,7 @@ namespace someip::rpc {
  */
 class RpcClientImpl : public transport::ITransportListener {
 public:
-    RpcClientImpl(uint16_t client_id)
+    explicit RpcClientImpl(uint16_t client_id)
         : client_id_(client_id),
           session_manager_(std::make_unique<SessionManager>()),
           transport_(std::make_shared<transport::UdpTransport>(transport::Endpoint("127.0.0.1", 0))),

--- a/src/rpc/rpc_server.cpp
+++ b/src/rpc/rpc_server.cpp
@@ -34,7 +34,7 @@ namespace someip::rpc {
  */
 class RpcServerImpl : public transport::ITransportListener {
 public:
-    RpcServerImpl(uint16_t service_id)
+    explicit RpcServerImpl(uint16_t service_id)
         : service_id_(service_id),
           transport_(std::make_shared<transport::UdpTransport>(transport::Endpoint("127.0.0.1", 30490))),
           running_(false) {

--- a/src/sd/sd_client.cpp
+++ b/src/sd/sd_client.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<transport::UdpTransport> create_sd_transport(const SdConfig& con
  */
 class SdClientImpl : public transport::ITransportListener {
 public:
-    SdClientImpl(const SdConfig& config)
+    explicit SdClientImpl(const SdConfig& config)
         : config_(config),
           transport_(create_sd_transport(config)),
           next_request_id_(1),

--- a/src/sd/sd_message.cpp
+++ b/src/sd/sd_message.cpp
@@ -44,7 +44,8 @@ std::vector<uint8_t> SdEntry::serialize() const {
     data.push_back(index2_);
 
     // Byte 3: #Opt1 (upper 4 bits) | #Opt2 (lower 4 bits)
-    data.push_back(static_cast<uint8_t>((num_opts1_ << 4) | (num_opts2_ & 0x0F)));
+    data.push_back(static_cast<uint8_t>((static_cast<uint32_t>(num_opts1_) << 4U) |
+                                        (static_cast<uint32_t>(num_opts2_) & 0x0FU)));
 
     // Bytes 4-5: Service ID — derived classes override
     data.push_back(0);
@@ -58,9 +59,9 @@ std::vector<uint8_t> SdEntry::serialize() const {
     data.push_back(0);
 
     // Bytes 9-11: TTL (24-bit)
-    data.push_back((ttl_ >> 16) & 0xFF);
-    data.push_back((ttl_ >> 8) & 0xFF);
-    data.push_back(ttl_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((ttl_ >> 16U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((ttl_ >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(ttl_ & 0xFFU));
 
     // Bytes 12-15: Minor Version or EventGroup fields — derived classes override
     data.push_back(0);
@@ -81,8 +82,8 @@ bool SdEntry::deserialize(const std::vector<uint8_t>& data, size_t& offset) {
     index1_ = data[offset++];                          // byte 1
     index2_ = data[offset++];                          // byte 2
     const uint8_t opts_byte = data[offset++];          // byte 3
-    num_opts1_ = (opts_byte >> 4) & 0x0F;
-    num_opts2_ = opts_byte & 0x0F;
+    num_opts1_ = static_cast<uint8_t>((static_cast<uint32_t>(opts_byte) >> 4U) & 0x0FU);
+    num_opts2_ = static_cast<uint8_t>(static_cast<uint32_t>(opts_byte) & 0x0FU);
 
     // Bytes 4-15 handled by derived classes
     return true;
@@ -94,12 +95,12 @@ std::vector<uint8_t> ServiceEntry::serialize() const {
     std::vector<uint8_t> data = SdEntry::serialize();
 
     // Bytes 4-5: Service ID
-    data[4] = (service_id_ >> 8) & 0xFF;
-    data[5] = service_id_ & 0xFF;
+    data[4] = static_cast<uint8_t>((static_cast<uint32_t>(service_id_) >> 8U) & 0xFFU);
+    data[5] = static_cast<uint8_t>(service_id_ & 0xFFU);
 
     // Bytes 6-7: Instance ID
-    data[6] = (instance_id_ >> 8) & 0xFF;
-    data[7] = instance_id_ & 0xFF;
+    data[6] = static_cast<uint8_t>((static_cast<uint32_t>(instance_id_) >> 8U) & 0xFFU);
+    data[7] = static_cast<uint8_t>(instance_id_ & 0xFFU);
 
     // Byte 8: Major Version
     data[8] = major_version_;
@@ -122,10 +123,13 @@ bool ServiceEntry::deserialize(const std::vector<uint8_t>& data, size_t& offset)
 
     // SdEntry::deserialize consumed bytes 0-4 (type, idx1, idx2, opts, skip).
     // We're now at byte 5 within the 16-byte entry.
-    service_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
-    instance_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 2]) << 8) | data[offset + 3]);
+    service_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8U) |
+                                        static_cast<uint32_t>(data[offset + 1]));
+    instance_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 2]) << 8U) |
+                                         static_cast<uint32_t>(data[offset + 3]));
     major_version_ = data[offset + 4];
-    ttl_ = (static_cast<uint32_t>(data[offset + 5]) << 16) | (static_cast<uint32_t>(data[offset + 6]) << 8) | data[offset + 7];
+    ttl_ = (static_cast<uint32_t>(data[offset + 5]) << 16U) | (static_cast<uint32_t>(data[offset + 6]) << 8U) |
+           static_cast<uint32_t>(data[offset + 7]);
     minor_version_ = data[offset + 11];
 
     offset += 12;
@@ -138,20 +142,20 @@ std::vector<uint8_t> EventGroupEntry::serialize() const {
     std::vector<uint8_t> data = SdEntry::serialize();
 
     // Bytes 4-5: Service ID
-    data[4] = (service_id_ >> 8) & 0xFF;
-    data[5] = service_id_ & 0xFF;
+    data[4] = static_cast<uint8_t>((static_cast<uint32_t>(service_id_) >> 8U) & 0xFFU);
+    data[5] = static_cast<uint8_t>(service_id_ & 0xFFU);
 
     // Bytes 6-7: Instance ID
-    data[6] = (instance_id_ >> 8) & 0xFF;
-    data[7] = instance_id_ & 0xFF;
+    data[6] = static_cast<uint8_t>((static_cast<uint32_t>(instance_id_) >> 8U) & 0xFFU);
+    data[7] = static_cast<uint8_t>(instance_id_ & 0xFFU);
 
     // Byte 8: Major Version
     data[8] = major_version_;
 
     // Bytes 12-13: Reserved + Counter (left as zero from base)
     // Bytes 14-15: EventGroup ID
-    data[14] = (eventgroup_id_ >> 8) & 0xFF;
-    data[15] = eventgroup_id_ & 0xFF;
+    data[14] = static_cast<uint8_t>((static_cast<uint32_t>(eventgroup_id_) >> 8U) & 0xFFU);
+    data[15] = static_cast<uint8_t>(eventgroup_id_ & 0xFFU);
 
     return data;
 }
@@ -166,11 +170,15 @@ bool EventGroupEntry::deserialize(const std::vector<uint8_t>& data, size_t& offs
         return false;
     }
 
-    service_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
-    instance_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 2]) << 8) | data[offset + 3]);
+    service_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8U) |
+                                        static_cast<uint32_t>(data[offset + 1]));
+    instance_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 2]) << 8U) |
+                                         static_cast<uint32_t>(data[offset + 3]));
     major_version_ = data[offset + 4];
-    ttl_ = (static_cast<uint32_t>(data[offset + 5]) << 16) | (static_cast<uint32_t>(data[offset + 6]) << 8) | data[offset + 7];
-    eventgroup_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 10]) << 8) | data[offset + 11]);
+    ttl_ = (static_cast<uint32_t>(data[offset + 5]) << 16U) | (static_cast<uint32_t>(data[offset + 6]) << 8U) |
+           static_cast<uint32_t>(data[offset + 7]);
+    eventgroup_id_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset + 10]) << 8U) |
+                                           static_cast<uint32_t>(data[offset + 11]));
 
     offset += 12;
     return true;
@@ -181,8 +189,8 @@ std::vector<uint8_t> SdOption::serialize() const {
     std::vector<uint8_t> data;
 
     // Length (2 bytes)
-    data.push_back((length_ >> 8) & 0xFF);
-    data.push_back(length_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((static_cast<uint32_t>(length_) >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(length_ & 0xFFU));
 
     // Type (1 byte)
     data.push_back(static_cast<uint8_t>(type_));
@@ -198,7 +206,8 @@ bool SdOption::deserialize(const std::vector<uint8_t>& data, size_t& offset) {
         return false;
     }
 
-    length_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
+    length_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8U) |
+                                    static_cast<uint32_t>(data[offset + 1]));
     offset += 2;
 
     type_ = static_cast<OptionType>(data[offset++]);
@@ -214,10 +223,10 @@ std::vector<uint8_t> IPv4EndpointOption::serialize() const {
 
     // IPv4 Address (4 bytes, network byte order)
     // ipv4_address_ is already in network byte order
-    data.push_back((ipv4_address_ >> 24) & 0xFF);
-    data.push_back((ipv4_address_ >> 16) & 0xFF);
-    data.push_back((ipv4_address_ >> 8) & 0xFF);
-    data.push_back(ipv4_address_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 24U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 16U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(ipv4_address_ & 0xFFU));
 
     // Reserved (1 byte)
     data.push_back(0);
@@ -227,13 +236,13 @@ std::vector<uint8_t> IPv4EndpointOption::serialize() const {
 
     // Port (2 bytes, network byte order)
     uint16_t network_port = someip_htons(port_);
-    data.push_back((network_port >> 8) & 0xFF);
-    data.push_back(network_port & 0xFF);
+    data.push_back(static_cast<uint8_t>((static_cast<uint32_t>(network_port) >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(network_port & 0xFFU));
 
     // Update length (8 bytes of data after the option header)
     uint16_t const length = 8;
-    data[0] = (length >> 8) & 0xFF;
-    data[1] = length & 0xFF;
+    data[0] = static_cast<uint8_t>((static_cast<uint32_t>(length) >> 8U) & 0xFFU);
+    data[1] = static_cast<uint8_t>(length & 0xFFU);
 
     return data;
 }
@@ -249,19 +258,19 @@ bool IPv4EndpointOption::deserialize(const std::vector<uint8_t>& data, size_t& o
     }
 
     // IPv4 Address (4 bytes, network byte order)
-    ipv4_address_ = (static_cast<uint32_t>(data[offset]) << 24) |
-                    (static_cast<uint32_t>(data[offset + 1]) << 16) |
-                    (static_cast<uint32_t>(data[offset + 2]) << 8) |
+    ipv4_address_ = (static_cast<uint32_t>(data[offset]) << 24U) |
+                    (static_cast<uint32_t>(data[offset + 1]) << 16U) |
+                    (static_cast<uint32_t>(data[offset + 2]) << 8U) |
                     static_cast<uint32_t>(data[offset + 3]);
     offset += 4;
 
     // Validate IP address (REQ_SD_064_E01)
-    if (ipv4_address_ == 0 || ipv4_address_ == 0xFFFFFFFF) {
+    if (ipv4_address_ == 0 || ipv4_address_ == 0xFFFFFFFFU) {
         std::cout << "Warning: Invalid IP address in endpoint option: "
-                  << ((ipv4_address_ >> 24) & 0xFF) << "."
-                  << ((ipv4_address_ >> 16) & 0xFF) << "."
-                  << ((ipv4_address_ >> 8) & 0xFF) << "."
-                  << (ipv4_address_ & 0xFF) << '\n';
+                  << ((ipv4_address_ >> 24U) & 0xFFU) << "."
+                  << ((ipv4_address_ >> 16U) & 0xFFU) << "."
+                  << ((ipv4_address_ >> 8U) & 0xFFU) << "."
+                  << (ipv4_address_ & 0xFFU) << '\n';
         // Continue processing despite invalid address
     }
 
@@ -272,7 +281,8 @@ bool IPv4EndpointOption::deserialize(const std::vector<uint8_t>& data, size_t& o
     protocol_ = data[offset++];
 
     // Port (2 bytes, network byte order)
-    uint16_t network_port = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
+    uint16_t network_port = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8U) |
+                                                   static_cast<uint32_t>(data[offset + 1]));
     port_ = someip_ntohs(network_port);
     offset += 2;
 
@@ -302,22 +312,22 @@ std::vector<uint8_t> IPv4MulticastOption::serialize() const {
     std::vector<uint8_t> data = SdOption::serialize();
 
     // IPv4 Address (4 bytes)
-    data.push_back((ipv4_address_ >> 24) & 0xFF);
-    data.push_back((ipv4_address_ >> 16) & 0xFF);
-    data.push_back((ipv4_address_ >> 8) & 0xFF);
-    data.push_back(ipv4_address_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 24U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 16U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((ipv4_address_ >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(ipv4_address_ & 0xFFU));
 
     // Reserved (1 byte)
     data.push_back(0);
 
     // Port (2 bytes)
-    data.push_back((port_ >> 8) & 0xFF);
-    data.push_back(port_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((static_cast<uint32_t>(port_) >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(port_ & 0xFFU));
 
     // Update length (7 bytes: 4 address + 1 reserved + 2 port)
     uint16_t const length = 7;
-    data[0] = (length >> 8) & 0xFF;
-    data[1] = length & 0xFF;
+    data[0] = static_cast<uint8_t>((static_cast<uint32_t>(length) >> 8U) & 0xFFU);
+    data[1] = static_cast<uint8_t>(length & 0xFFU);
 
     return data;
 }
@@ -332,21 +342,22 @@ bool IPv4MulticastOption::deserialize(const std::vector<uint8_t>& data, size_t& 
         return false;
     }
 
-    ipv4_address_ = (static_cast<uint32_t>(data[offset]) << 24) |
-                    (static_cast<uint32_t>(data[offset + 1]) << 16) |
-                    (static_cast<uint32_t>(data[offset + 2]) << 8) |
+    ipv4_address_ = (static_cast<uint32_t>(data[offset]) << 24U) |
+                    (static_cast<uint32_t>(data[offset + 1]) << 16U) |
+                    (static_cast<uint32_t>(data[offset + 2]) << 8U) |
                     static_cast<uint32_t>(data[offset + 3]);
     offset += 5;  // Skip address + reserved
 
     // Validate IP address (REQ_SD_064_E01)
-    if (ipv4_address_ == 0 || ipv4_address_ == 0xFFFFFFFF) {
+    if (ipv4_address_ == 0 || ipv4_address_ == 0xFFFFFFFFU) {
         std::cout << "Warning: Invalid IP address in multicast option: "
-                  << ((ipv4_address_ >> 24) & 0xFF) << "."
-                  << ((ipv4_address_ >> 16) & 0xFF) << "."
-                  << ((ipv4_address_ >> 8) & 0xFF) << "."
-                  << (ipv4_address_ & 0xFF) << '\n';
+                  << ((ipv4_address_ >> 24U) & 0xFFU) << "."
+                  << ((ipv4_address_ >> 16U) & 0xFFU) << "."
+                  << ((ipv4_address_ >> 8U) & 0xFFU) << "."
+                  << (ipv4_address_ & 0xFFU) << '\n';
     }
-    port_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
+    port_ = static_cast<uint16_t>((static_cast<uint32_t>(data[offset]) << 8U) |
+                                   static_cast<uint32_t>(data[offset + 1]));
     offset += 2;
 
     return true;
@@ -372,8 +383,8 @@ std::vector<uint8_t> ConfigurationOption::serialize() const {
 
     // Update length
     const auto length = static_cast<uint16_t>(config_string_.size());
-    data[2] = (length >> 8) & 0xFF;
-    data[3] = length & 0xFF;
+    data[2] = static_cast<uint8_t>((static_cast<uint32_t>(length) >> 8U) & 0xFFU);
+    data[3] = static_cast<uint8_t>(length & 0xFFU);
 
     return data;
 }
@@ -410,13 +421,13 @@ std::vector<uint8_t> SdMessage::serialize() const {
     std::vector<uint8_t> data;
 
     // Flags (1 byte) - ensure reserved bits 5-0 are zero (REQ_SD_013)
-    const uint8_t flags_to_send = flags_ & 0xC0;
+    const uint8_t flags_to_send = static_cast<uint8_t>(static_cast<uint32_t>(flags_) & 0xC0U);
     data.push_back(flags_to_send);
 
     // Reserved (3 bytes)
-    data.push_back((reserved_ >> 16) & 0xFF);
-    data.push_back((reserved_ >> 8) & 0xFF);
-    data.push_back(reserved_ & 0xFF);
+    data.push_back(static_cast<uint8_t>((reserved_ >> 16U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>((reserved_ >> 8U) & 0xFFU));
+    data.push_back(static_cast<uint8_t>(reserved_ & 0xFFU));
 
     // Length of Entries Array (4 bytes) - placeholder
     const size_t entries_len_offset = data.size();
@@ -434,10 +445,10 @@ std::vector<uint8_t> SdMessage::serialize() const {
     const uint32_t entries_length = static_cast<uint32_t>(data.size() - entries_start);
 
     // Back-fill Length of Entries Array
-    data[entries_len_offset]     = (entries_length >> 24) & 0xFF;
-    data[entries_len_offset + 1] = (entries_length >> 16) & 0xFF;
-    data[entries_len_offset + 2] = (entries_length >> 8) & 0xFF;
-    data[entries_len_offset + 3] = entries_length & 0xFF;
+    data[entries_len_offset]     = static_cast<uint8_t>((entries_length >> 24U) & 0xFFU);
+    data[entries_len_offset + 1] = static_cast<uint8_t>((entries_length >> 16U) & 0xFFU);
+    data[entries_len_offset + 2] = static_cast<uint8_t>((entries_length >> 8U) & 0xFFU);
+    data[entries_len_offset + 3] = static_cast<uint8_t>(entries_length & 0xFFU);
 
     // Length of Options Array (4 bytes) - placeholder
     const size_t options_len_offset = data.size();
@@ -455,10 +466,10 @@ std::vector<uint8_t> SdMessage::serialize() const {
     const uint32_t options_length = static_cast<uint32_t>(data.size() - options_start);
 
     // Back-fill Length of Options Array
-    data[options_len_offset]     = (options_length >> 24) & 0xFF;
-    data[options_len_offset + 1] = (options_length >> 16) & 0xFF;
-    data[options_len_offset + 2] = (options_length >> 8) & 0xFF;
-    data[options_len_offset + 3] = options_length & 0xFF;
+    data[options_len_offset]     = static_cast<uint8_t>((options_length >> 24U) & 0xFFU);
+    data[options_len_offset + 1] = static_cast<uint8_t>((options_length >> 16U) & 0xFFU);
+    data[options_len_offset + 2] = static_cast<uint8_t>((options_length >> 8U) & 0xFFU);
+    data[options_len_offset + 3] = static_cast<uint8_t>(options_length & 0xFFU);
 
     return data;
 }
@@ -473,13 +484,14 @@ bool SdMessage::deserialize(const std::vector<uint8_t>& data) {
 
     // Flags (1 byte) + Reserved (3 bytes)
     flags_ = data[offset++];
-    reserved_ = (static_cast<uint32_t>(data[offset]) << 16) | (static_cast<uint32_t>(data[offset + 1]) << 8) | data[offset + 2];
+    reserved_ = (static_cast<uint32_t>(data[offset]) << 16U) | (static_cast<uint32_t>(data[offset + 1]) << 8U) |
+              static_cast<uint32_t>(data[offset + 2]);
     offset += 3;
 
     // Length of Entries Array (4 bytes)
-    const uint32_t entries_length = (static_cast<uint32_t>(data[offset]) << 24) |
-                                    (static_cast<uint32_t>(data[offset + 1]) << 16) |
-                                    (static_cast<uint32_t>(data[offset + 2]) << 8) |
+    const uint32_t entries_length = (static_cast<uint32_t>(data[offset]) << 24U) |
+                                    (static_cast<uint32_t>(data[offset + 1]) << 16U) |
+                                    (static_cast<uint32_t>(data[offset + 2]) << 8U) |
                                     static_cast<uint32_t>(data[offset + 3]);
     offset += 4;
 
@@ -515,9 +527,9 @@ bool SdMessage::deserialize(const std::vector<uint8_t>& data) {
     if (offset + 4 > data.size()) {
         return true;  // no options section present
     }
-    const uint32_t options_length = (static_cast<uint32_t>(data[offset]) << 24) |
-                                    (static_cast<uint32_t>(data[offset + 1]) << 16) |
-                                    (static_cast<uint32_t>(data[offset + 2]) << 8) |
+    const uint32_t options_length = (static_cast<uint32_t>(data[offset]) << 24U) |
+                                    (static_cast<uint32_t>(data[offset + 1]) << 16U) |
+                                    (static_cast<uint32_t>(data[offset + 2]) << 8U) |
                                     static_cast<uint32_t>(data[offset + 3]);
     offset += 4;
 
@@ -546,7 +558,7 @@ bool SdMessage::deserialize(const std::vector<uint8_t>& data) {
             option = std::make_unique<IPv4MulticastOption>();
         } else {
             const uint16_t option_len = static_cast<uint16_t>(
-                (static_cast<uint32_t>(data[offset]) << 8) | data[offset + 1]);
+                (static_cast<uint32_t>(data[offset]) << 8U) | static_cast<uint32_t>(data[offset + 1]));
             if (offset + 4 + option_len > options_end) {
                 return false;
             }

--- a/src/sd/sd_server.cpp
+++ b/src/sd/sd_server.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<transport::UdpTransport> create_sd_transport(const SdConfig& con
  */
 class SdServerImpl : public transport::ITransportListener {
 public:
-    SdServerImpl(const SdConfig& config)
+    explicit SdServerImpl(const SdConfig& config)
         : config_(config),
           transport_(create_sd_transport(config)),
           next_offer_delay_(config.initial_delay),

--- a/src/serialization/serializer.cpp
+++ b/src/serialization/serializer.cpp
@@ -170,27 +170,27 @@ void Serializer::add_padding(size_t bytes) {
 
 void Serializer::append_be_uint16(uint16_t value) {
     const uint16_t be_value = someip_htons(value);
-    auto bytes = reinterpret_cast<const uint8_t*>(&be_value);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&be_value);
     buffer_.insert(buffer_.end(), bytes, bytes + sizeof(uint16_t));
 }
 
 void Serializer::append_be_uint32(uint32_t value) {
     const uint32_t be_value = someip_htonl(value);
-    auto bytes = reinterpret_cast<const uint8_t*>(&be_value);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&be_value);
     buffer_.insert(buffer_.end(), bytes, bytes + sizeof(uint32_t));
 }
 
 void Serializer::append_be_uint64(uint64_t value) {
     // Manual big-endian conversion for macOS compatibility
-    const uint64_t be_value = ((value & 0xFF00000000000000ULL) >> 56) |
-                        ((value & 0x00FF000000000000ULL) >> 40) |
-                        ((value & 0x0000FF0000000000ULL) >> 24) |
-                        ((value & 0x000000FF00000000ULL) >> 8) |
-                        ((value & 0x00000000FF000000ULL) << 8) |
-                        ((value & 0x0000000000FF0000ULL) << 24) |
-                        ((value & 0x000000000000FF00ULL) << 40) |
-                        ((value & 0x00000000000000FFULL) << 56);
-    auto bytes = reinterpret_cast<const uint8_t*>(&be_value);
+    const uint64_t be_value = ((value & 0xFF00000000000000ULL) >> 56U) |
+                        ((value & 0x00FF000000000000ULL) >> 40U) |
+                        ((value & 0x0000FF0000000000ULL) >> 24U) |
+                        ((value & 0x000000FF00000000ULL) >> 8U) |
+                        ((value & 0x00000000FF000000ULL) << 8U) |
+                        ((value & 0x0000000000FF0000ULL) << 24U) |
+                        ((value & 0x000000000000FF00ULL) << 40U) |
+                        ((value & 0x00000000000000FFULL) << 56U);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&be_value);
     buffer_.insert(buffer_.end(), bytes, bytes + sizeof(uint64_t));
 }
 
@@ -470,14 +470,14 @@ std::optional<uint64_t> Deserializer::read_be_uint64() {
     position_ += sizeof(uint64_t);
 
     // Manual big-endian to host conversion for macOS compatibility
-    return ((be_value & 0xFF00000000000000ULL) >> 56) |
-           ((be_value & 0x00FF000000000000ULL) >> 40) |
-           ((be_value & 0x0000FF0000000000ULL) >> 24) |
-           ((be_value & 0x000000FF00000000ULL) >> 8) |
-           ((be_value & 0x00000000FF000000ULL) << 8) |
-           ((be_value & 0x0000000000FF0000ULL) << 24) |
-           ((be_value & 0x000000000000FF00ULL) << 40) |
-           ((be_value & 0x00000000000000FFULL) << 56);
+    return ((be_value & 0xFF00000000000000ULL) >> 56U) |
+           ((be_value & 0x00FF000000000000ULL) >> 40U) |
+           ((be_value & 0x0000FF0000000000ULL) >> 24U) |
+           ((be_value & 0x000000FF00000000ULL) >> 8U) |
+           ((be_value & 0x00000000FF000000ULL) << 8U) |
+           ((be_value & 0x0000000000FF0000ULL) << 24U) |
+           ((be_value & 0x000000000000FF00ULL) << 40U) |
+           ((be_value & 0x00000000000000FFULL) << 56U);
 }
 
 std::optional<int16_t> Deserializer::read_be_int16() {

--- a/src/tp/tp_manager.cpp
+++ b/src/tp/tp_manager.cpp
@@ -65,7 +65,8 @@ TpResult TpManager::segment_message(const Message& message, uint32_t& transfer_i
     // Create new transfer
     transfer_id = next_transfer_id_++;
     uint32_t const message_id =
-        (static_cast<uint32_t>(message.get_service_id()) << 16) | message.get_method_id();
+        (static_cast<uint32_t>(message.get_service_id()) << 16U) |
+        static_cast<uint32_t>(message.get_method_id());
 
     TpTransfer transfer(transfer_id, message_id);
 

--- a/src/tp/tp_reassembler.cpp
+++ b/src/tp/tp_reassembler.cpp
@@ -50,13 +50,13 @@ bool TpReassembler::parse_tp_header(const std::vector<uint8_t>& payload,
 
     // TP header starts at offset 16 (after SOME/IP header)
     uint32_t const tp_header =
-        (static_cast<uint32_t>(payload[16]) << 24) |
-        (static_cast<uint32_t>(payload[17]) << 16) |
-        (static_cast<uint32_t>(payload[18]) << 8) |
+        (static_cast<uint32_t>(payload[16]) << 24U) |
+        (static_cast<uint32_t>(payload[17]) << 16U) |
+        (static_cast<uint32_t>(payload[18]) << 8U) |
         static_cast<uint32_t>(payload[19]);
 
     // Extract offset (28 bits, divided by 4 to get byte offset)
-    uint32_t const offset_units = tp_header >> 4;
+    uint32_t const offset_units = tp_header >> 4U;
     offset = offset_units * 16;  // Convert back to bytes
 
     // Check offset alignment (REQ_TP_015_E01)
@@ -66,7 +66,7 @@ bool TpReassembler::parse_tp_header(const std::vector<uint8_t>& payload,
     }
 
     // Extract more segments flag (bit 0)
-    more_segments = (tp_header & 0x01) != 0;
+    more_segments = (tp_header & 0x01U) != 0;
 
     // Reserved bits (bits 1-3) are ignored (REQ_TP_018)
 

--- a/src/tp/tp_segmenter.cpp
+++ b/src/tp/tp_segmenter.cpp
@@ -116,10 +116,10 @@ TpResult TpSegmenter::create_multi_segments(const Message& message,
 
         // Update SOME/IP length field (REQ_TP_022): 8 + 4 + payload_size
         uint32_t const segment_length = 8 + 4 + first_payload_size;
-        header[4] = (segment_length >> 24) & 0xFF;  // Length field in SOME/IP header
-        header[5] = (segment_length >> 16) & 0xFF;
-        header[6] = (segment_length >> 8) & 0xFF;
-        header[7] = segment_length & 0xFF;
+        header[4] = static_cast<uint8_t>((segment_length >> 24U) & 0xFFU);  // Length field in SOME/IP header
+        header[5] = static_cast<uint8_t>((segment_length >> 16U) & 0xFFU);
+        header[6] = static_cast<uint8_t>((segment_length >> 8U) & 0xFFU);
+        header[7] = static_cast<uint8_t>(segment_length & 0xFFU);
 
         segment.header.segment_length = static_cast<uint16_t>(header.size());
         segment.payload = std::move(header);
@@ -157,11 +157,11 @@ TpResult TpSegmenter::create_multi_segments(const Message& message,
         bool const more_segments = (payload_offset + payload_size) < total_length;
         // Build TP header bytes directly (no SOME/IP header for subsequent segments)
         uint32_t const offset_units = payload_offset / 16;
-        uint32_t const tp_header = (offset_units << 4) | (more_segments ? 0x01 : 0x00);
-        segment_data.push_back((tp_header >> 24) & 0xFF);
-        segment_data.push_back((tp_header >> 16) & 0xFF);
-        segment_data.push_back((tp_header >> 8) & 0xFF);
-        segment_data.push_back(tp_header & 0xFF);
+        uint32_t const tp_header = (offset_units << 4U) | (more_segments ? 0x01U : 0x00U);
+        segment_data.push_back(static_cast<uint8_t>((tp_header >> 24U) & 0xFFU));
+        segment_data.push_back(static_cast<uint8_t>((tp_header >> 16U) & 0xFFU));
+        segment_data.push_back(static_cast<uint8_t>((tp_header >> 8U) & 0xFFU));
+        segment_data.push_back(static_cast<uint8_t>(tp_header & 0xFFU));
         // Add payload data
         segment_data.insert(segment_data.end(), payload.begin() + payload_offset,
                            payload.begin() + payload_offset + payload_size);
@@ -204,7 +204,7 @@ void TpSegmenter::serialize_tp_header(std::vector<uint8_t>& payload,
     uint32_t const offset_units = offset / 16;
 
     // Check for offset overflow (REQ_TP_013_E01)
-    if (offset_units > 0x0FFFFFFF) {  // 28 bits max
+    if (offset_units > 0x0FFFFFFFU) {  // 28 bits max
         // This should not happen in practice with reasonable message sizes
         // but we check for completeness
     }
@@ -216,14 +216,14 @@ void TpSegmenter::serialize_tp_header(std::vector<uint8_t>& payload,
     }
 
     // Build TP header: offset (28 bits) | reserved (3 bits = 0) | more_segments (1 bit)
-    uint32_t const tp_header = (offset_units << 4) | (more_segments ? 0x01 : 0x00);
+    uint32_t const tp_header = (offset_units << 4U) | (more_segments ? 0x01U : 0x00U);
 
     // Serialize in big-endian
     std::array<uint8_t, 4> header_bytes{};
-    header_bytes[0] = (tp_header >> 24) & 0xFF;
-    header_bytes[1] = (tp_header >> 16) & 0xFF;
-    header_bytes[2] = (tp_header >> 8) & 0xFF;
-    header_bytes[3] = tp_header & 0xFF;
+    header_bytes[0] = static_cast<uint8_t>((tp_header >> 24U) & 0xFFU);
+    header_bytes[1] = static_cast<uint8_t>((tp_header >> 16U) & 0xFFU);
+    header_bytes[2] = static_cast<uint8_t>((tp_header >> 8U) & 0xFFU);
+    header_bytes[3] = static_cast<uint8_t>(tp_header & 0xFFU);
 
     // Insert TP header after SOME/IP header (16 bytes)
     payload.insert(payload.begin() + 16, header_bytes.begin(), header_bytes.end());
@@ -235,8 +235,9 @@ void TpSegmenter::serialize_tp_header(std::vector<uint8_t>& payload,
  */
 MessageType TpSegmenter::add_tp_flag(MessageType type) const {
     // TP flag is bit 5 (0x20)
-    uint8_t const tp_flag = 0x20;
-    return static_cast<MessageType>(static_cast<uint8_t>(type) | tp_flag);
+    uint8_t const tp_flag = 0x20U;
+    return static_cast<MessageType>(static_cast<uint32_t>(static_cast<uint8_t>(type)) |
+                                    static_cast<uint32_t>(tp_flag));
 }
 
 }  // namespace someip::tp

--- a/src/tp/tp_segmenter.cpp
+++ b/src/tp/tp_segmenter.cpp
@@ -84,7 +84,7 @@ TpResult TpSegmenter::create_multi_segments(const Message& message,
                                           std::vector<TpSegment>& segments) {
 
     auto const total_length = static_cast<uint32_t>(payload.size());
-    uint16_t payload_offset = 0;  // Offset into the payload data
+    uint32_t payload_offset = 0;  // Offset into the payload data
     uint8_t const sequence_number = next_sequence_number_;
 
     // Create a copy of the message with TP flag added to message type
@@ -198,7 +198,7 @@ void TpSegmenter::update_config(const TpConfig& config) {
  * @implements REQ_TP_013_E01, REQ_TP_015_E01
  */
 void TpSegmenter::serialize_tp_header(std::vector<uint8_t>& payload,
-                                     uint16_t offset, bool more_segments) {
+                                     uint32_t offset, bool more_segments) {
     // TP header is 4 bytes: [Offset (28 bits) | Reserved (3 bits) | More Segments (1 bit)]
     // Offset is in units of 16 bytes, so divide by 16
     uint32_t const offset_units = offset / 16;

--- a/src/transport/endpoint.cpp
+++ b/src/transport/endpoint.cpp
@@ -149,7 +149,8 @@ bool Endpoint::is_valid_ipv4(const std::string& address) const {
             return false;
         }
 
-        int const val = std::atoi(address.substr(start, digit_len).c_str());
+        int const val = static_cast<int>(
+            std::strtol(address.substr(start, digit_len).c_str(), nullptr, 10));
         if (val < 0 || val > 255) {
             return false;
         }

--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -525,7 +525,9 @@ bool TcpTransport::parse_message_from_buffer(std::vector<uint8_t>& buffer, Messa
 
     // Parse message length from header (bytes 4-7 in big-endian)
     // Length field contains length from client_id to end of message
-    const uint32_t length_from_client_id = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
+    const uint32_t length_from_client_id =
+        (static_cast<uint32_t>(buffer[4]) << 24U) | (static_cast<uint32_t>(buffer[5]) << 16U) |
+        (static_cast<uint32_t>(buffer[6]) << 8U) | static_cast<uint32_t>(buffer[7]);
 
     if (length_from_client_id < 8 || length_from_client_id > MAX_MESSAGE_SIZE) {
         // Invalid message length - try to resync by skipping this potential header
@@ -535,10 +537,11 @@ bool TcpTransport::parse_message_from_buffer(std::vector<uint8_t>& buffer, Messa
 
         while (search_start + SOMEIP_HEADER_SIZE <= buffer.size()) {
             // Check if this looks like a valid SOME/IP header
-            uint32_t potential_msg_id = (buffer[search_start] << 24) |
-                                       (buffer[search_start + 1] << 16) |
-                                       (buffer[search_start + 2] << 8) |
-                                       buffer[search_start + 3];
+            uint32_t potential_msg_id =
+                (static_cast<uint32_t>(buffer[search_start]) << 24U) |
+                (static_cast<uint32_t>(buffer[search_start + 1]) << 16U) |
+                (static_cast<uint32_t>(buffer[search_start + 2]) << 8U) |
+                static_cast<uint32_t>(buffer[search_start + 3]);
             if (potential_msg_id != 0) {  // Found a non-zero message ID
                 // Discard data before this potential header
                 buffer.erase(buffer.begin(),


### PR DESCRIPTION
## Summary

Fifth batch of clang-tidy remediations eliminating the largest remaining violation category — **signed bitwise operations** — across 19 files.

### Changes by category

**Signed bitwise (`hicpp-signed-bitwise`, ~349 fixes)**
- Cast `uint8_t`/`uint16_t` to `uint32_t` before bitwise shifts to prevent UB from signed `int` promotion
- Add `U` suffix to hex literals used with bitwise operators (`0xFF` → `0xFFU`, etc.)
- Fixed across all modules: sd_message (119), types.h (102), tp_segmenter (25), sd_message.h (24), net_impl headers (18), serializer (16), e2e_crc (16), event_subscriber (9), tcp_transport (8), standard_profile (6), tp_reassembler (5), tp_manager (1)

**Explicit conversions (5 fixes)**
- `hicpp-explicit-conversions`: Add `explicit` to single-argument Pimpl constructors (event_subscriber, rpc_client, rpc_server, sd_client, sd_server)

**Qualified auto (3 fixes)**
- `readability-qualified-auto`: Use `const auto*` for pointer declarations in serializer

**Error handling (1 fix)**
- `cert-err34-c`: Replace `atoi` with `strtol` in endpoint IPv4 validation

## Test plan
- [ ] All existing tests pass (Host, FreeRTOS, ThreadX, Zephyr, Windows)
- [ ] Clang-tidy quality gate passes
- [ ] No regressions in cross-compilation (ARM Cortex-M4)

Ref: #222

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized integer type handling with explicit casting in bitwise operations across multiple modules.
  * Updated several constructor declarations to include the `explicit` keyword.
  * Applied unsigned literal suffixes and widened type conversions in bit-manipulation expressions throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->