### PR TITLE
fix: repair Coverity Scan CI download URL and upgrade to Node.js 24 actions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -47,19 +47,19 @@ jobs:
           fi
           exit $missing
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download Coverity Build Tool
         run: |
-          curl -fsS \
-            -d "token=${COVERITY_SCAN_TOKEN}&project=vtz/opensomeip" \
+          curl -fsS --retry 3 --retry-delay 10 \
+            --data "token=${COVERITY_SCAN_TOKEN}&project=vtz%2Fopensomeip" \
             -o coverity_tool.tgz \
-            https://scan.coverity.com/download/linux64
+            https://scan.coverity.com/download/cxx/linux64
           mkdir -p coverity_tool
           tar xzf coverity_tool.tgz --strip-components=1 -C coverity_tool
 
       - name: Cache CMake FetchContent
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/_deps
           key: fetchcontent-coverity-${{ hashFiles('CMakeLists.txt') }}
@@ -79,10 +79,10 @@ jobs:
       - name: Submit to Coverity Scan
         run: |
           tar czf analysis-results.tgz cov-int
-          curl -fsS \
+          curl -fsS --retry 3 --retry-delay 10 \
             --form "token=${COVERITY_SCAN_TOKEN}" \
             --form "email=${COVERITY_EMAIL}" \
             --form file=@analysis-results.tgz \
             --form version="${{ github.sha }}" \
             --form description="Automated Coverity Scan from GitHub Actions" \
-            https://scan.coverity.com/builds?project=vtz/opensomeip
+            "https://scan.coverity.com/builds?project=vtz%2Fopensomeip"


### PR DESCRIPTION
Closes #240

## Summary
- Fix Coverity Scan download 404 by adding `cxx/` language-pack prefix to the download URL and URL-encoding the project name (`vtz%2Fopensomeip`)
- Upgrade `actions/checkout` and `actions/cache` from v4 to v5 (Node.js 24 runtime) to resolve the deprecation warning
- Add `--retry 3 --retry-delay 10` to both curl calls for transient failure resilience

## Root Cause
The download step was hitting `https://scan.coverity.com/download/linux64` which now returns 404. Coverity requires the language-pack in the URL path: `/download/cxx/linux64`. Additionally, the project name `vtz/opensomeip` was not URL-encoded in curl POST data.

## Test plan
- [ ] Coverity Scan workflow runs successfully on push to main (download + build + submit)
- [ ] Node.js 20 deprecation warning no longer appears

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability and robustness for code quality scanning processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vtz/opensomeip/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->