### PR TITLE
fix: add health check to Coverity workflow for service outages

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -49,7 +49,19 @@ jobs:
 
       - uses: actions/checkout@v5
 
+      - name: Check Coverity Scan availability
+        id: health
+        run: |
+          if curl -sSf --head --retry 2 --max-time 15 \
+              https://scan.coverity.com > /dev/null 2>&1; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Coverity Scan service is unreachable — skipping scan"
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download Coverity Build Tool
+        if: steps.health.outputs.available == 'true'
         run: |
           curl -fsS --retry 3 --retry-delay 10 \
             --data "token=${COVERITY_SCAN_TOKEN}&project=vtz%2Fopensomeip" \
@@ -59,6 +71,7 @@ jobs:
           tar xzf coverity_tool.tgz --strip-components=1 -C coverity_tool
 
       - name: Cache CMake FetchContent
+        if: steps.health.outputs.available == 'true'
         uses: actions/cache@v5
         with:
           path: build/_deps
@@ -67,6 +80,7 @@ jobs:
             fetchcontent-coverity-
 
       - name: Configure CMake
+        if: steps.health.outputs.available == 'true'
         run: >
           cmake -B build
           -DCMAKE_CXX_COMPILER=g++
@@ -74,9 +88,11 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
 
       - name: Build with cov-build
+        if: steps.health.outputs.available == 'true'
         run: coverity_tool/bin/cov-build --dir cov-int cmake --build build
 
       - name: Submit to Coverity Scan
+        if: steps.health.outputs.available == 'true'
         run: |
           tar czf analysis-results.tgz cov-int
           curl -fsS --retry 3 --retry-delay 10 \


### PR DESCRIPTION
## Summary
- Add a lightweight health check (HEAD request to `scan.coverity.com`) before the Coverity Build Tool download
- When the Coverity Scan service is unreachable, the job completes with a `::warning` annotation instead of failing with exit code 22
- All downstream steps (download, cache, build, submit) are gated on `steps.health.outputs.available == 'true'`, so real errors still surface when the service is operational

## Context
Coverity Scan is [currently down](https://scan.coverity.com/maintenance.html), causing every push to `main` to fail the Coverity CI job ([run #100](https://github.com/vtz/opensomeip/actions/runs/26010159884)). This is an external service outage — not a code or configuration issue.

## Test plan
- [ ] CI passes on this PR (health check correctly detects service unavailability)
- [ ] When Coverity service resumes, the workflow runs normally (download + build + submit)

Made with [Cursor](https://cursor.com)