### PR TITLE
ci: temporarily disable Coverity Scan while service is offline

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,16 +13,10 @@
 
 name: Coverity Scan
 
+# Disabled: Coverity Scan service is offline for upgrades (see #263).
+# Re-enable triggers once the service is restored (see #265).
 on:
-  schedule:
-    - cron: '0 4 * * 1'
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.cursor/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #263

## Summary
- Replace the `schedule` and `push` triggers on the Coverity Scan workflow with `workflow_dispatch` so it won't fire automatically while the service is down
- Keeps the full workflow intact for easy re-enabling once the service is restored
- Added comments referencing both the disable issue (#263) and the re-enable issue (#264, to be created)

## Context
The Coverity Scan service at `scan.coverity.com` is offline for server upgrades, causing a 404 on the tool download step on every push to `main`. This has been the case since at least the latest push today (May 23, 2026).

## Test plan
- [ ] Pushing to `main` no longer triggers the Coverity Scan workflow
- [ ] The workflow can still be triggered manually via `workflow_dispatch` for testing

Made with [Cursor](https://cursor.com)