### PR TITLE
fix: hardening follow-ups from PR #278 review

### DIFF
--- a/include/tp/tp_reassembler.h
+++ b/include/tp/tp_reassembler.h
@@ -61,10 +61,13 @@ public:
     /**
      * @brief Check if a message is currently being reassembled
      *
-     * @param message_id The message identifier
+     * @param message_id The message identifier (matches any buffer with this message_id)
      * @return true if reassembly is in progress
      */
     bool is_reassembling(uint32_t message_id) const;
+
+    /** @brief Check if a specific reassembly key is active */
+    bool is_reassembling(const TpReassemblyKey& key) const;
 
     /**
      * @brief Get reassembly progress for a message
@@ -76,12 +79,18 @@ public:
      */
     bool get_reassembly_progress(uint32_t message_id, uint32_t& received_bytes, uint32_t& total_bytes) const;
 
+    /** @brief Get reassembly progress by exact key */
+    bool get_reassembly_progress(const TpReassemblyKey& key, uint32_t& received_bytes, uint32_t& total_bytes) const;
+
     /**
      * @brief Cancel reassembly for a message
      *
-     * @param message_id The message identifier
+     * @param message_id The message identifier (cancels all buffers with this message_id)
      */
     void cancel_reassembly(uint32_t message_id);
+
+    /** @brief Cancel reassembly for an exact key */
+    void cancel_reassembly(const TpReassemblyKey& key);
 
     /**
      * @brief Process timeouts and cleanup stale reassembly buffers

--- a/include/tp/tp_reassembler.h
+++ b/include/tp/tp_reassembler.h
@@ -59,37 +59,67 @@ public:
     bool process_segment(const TpSegment& segment, platform::ByteBuffer& complete_message);
 
     /**
-     * @brief Check if a message is currently being reassembled
+     * @brief Check if any buffer with this message_id is being reassembled
      *
-     * @param message_id The message identifier (matches any buffer with this message_id)
-     * @return true if reassembly is in progress
+     * Scans all active buffers and returns true if at least one has a
+     * matching message_id.  When multiple transfers share a message_id
+     * (different client/session/message-type), this cannot distinguish
+     * them — use the TpReassemblyKey overload for per-transfer queries.
+     *
+     * @param message_id The message identifier
+     * @return true if at least one matching reassembly is in progress
      */
     bool is_reassembling(uint32_t message_id) const;
 
-    /** @brief Check if a specific reassembly key is active */
+    /**
+     * @brief Check if a specific transfer (exact composite key) is active
+     *
+     * O(1) lookup; unambiguous when multiple transfers share a message_id.
+     *
+     * @param key The full reassembly key
+     * @return true if the exact transfer is in progress
+     */
     bool is_reassembling(const TpReassemblyKey& key) const;
 
     /**
-     * @brief Get reassembly progress for a message
+     * @brief Get reassembly progress for the first buffer matching message_id
+     *
+     * When multiple buffers share message_id, returns the first match found
+     * (iteration order is unspecified).  Use the TpReassemblyKey overload
+     * for deterministic per-transfer progress.
      *
      * @param message_id The message identifier
-     * @param received_bytes Number of bytes received (output)
+     * @param received_bytes Number of bytes received so far (output)
      * @param total_bytes Total expected bytes (output)
-     * @return true if message found, false otherwise
+     * @return true if a matching buffer was found
      */
     bool get_reassembly_progress(uint32_t message_id, uint32_t& received_bytes, uint32_t& total_bytes) const;
 
-    /** @brief Get reassembly progress by exact key */
+    /**
+     * @brief Get reassembly progress for an exact transfer
+     *
+     * @param key The full reassembly key
+     * @param received_bytes Number of bytes received so far (output)
+     * @param total_bytes Total expected bytes (output)
+     * @return true if the transfer exists
+     */
     bool get_reassembly_progress(const TpReassemblyKey& key, uint32_t& received_bytes, uint32_t& total_bytes) const;
 
     /**
-     * @brief Cancel reassembly for a message
+     * @brief Cancel all reassembly buffers matching message_id
      *
-     * @param message_id The message identifier (cancels all buffers with this message_id)
+     * Erases every buffer whose key.message_id equals the argument.
+     * Use the TpReassemblyKey overload to cancel a single transfer.
+     *
+     * @param message_id The message identifier
      */
     void cancel_reassembly(uint32_t message_id);
 
-    /** @brief Cancel reassembly for an exact key */
+    /**
+     * @brief Cancel reassembly for one exact transfer
+     *
+     * @param key The full reassembly key
+     */
     void cancel_reassembly(const TpReassemblyKey& key);
 
     /**

--- a/src/serialization/serializer.cpp
+++ b/src/serialization/serializer.cpp
@@ -422,7 +422,7 @@ DeserializationResult<platform::String<>> Deserializer::deserialize_string() {
         return DeserializationResult<platform::String<>>::error(Result::MALFORMED_MESSAGE);
     }
 
-    if (position_ + length > buffer_.size()) {
+    if (position_ > buffer_.size() || length > buffer_.size() - position_) {
         return DeserializationResult<platform::String<>>::error(Result::MALFORMED_MESSAGE);
     }
 

--- a/src/tp/tp_reassembler.cpp
+++ b/src/tp/tp_reassembler.cpp
@@ -143,8 +143,15 @@ bool TpReassembler::process_segment(const TpSegment& segment, platform::ByteBuff
         return false;
     }
 
+    // Reject follow-up segments whose message_length disagrees with the
+    // buffer created by the FIRST segment.  A rogue segment with a larger
+    // message_length would pass validate_segment (which uses the segment's
+    // own message_length) but could exceed the buffer allocation.
+    if (segment.header.message_length != buffer->total_length) {
+        return false;
+    }
+
     if (!add_segment_to_buffer(*buffer, segment)) {
-        reassembly_buffers_.erase(key);
         return false;
     }
 
@@ -319,6 +326,11 @@ bool TpReassembler::is_reassembling(uint32_t message_id) const {
     return false;
 }
 
+bool TpReassembler::is_reassembling(const TpReassemblyKey& key) const {
+    platform::ScopedLock const lock(buffers_mutex_);
+    return reassembly_buffers_.find(key) != reassembly_buffers_.end();
+}
+
 bool TpReassembler::get_reassembly_progress(uint32_t message_id, uint32_t& received_bytes, uint32_t& total_bytes) const {
     platform::ScopedLock const lock(buffers_mutex_);
 
@@ -342,6 +354,27 @@ bool TpReassembler::get_reassembly_progress(uint32_t message_id, uint32_t& recei
     return false;
 }
 
+bool TpReassembler::get_reassembly_progress(const TpReassemblyKey& key, uint32_t& received_bytes, uint32_t& total_bytes) const {
+    platform::ScopedLock const lock(buffers_mutex_);
+
+    auto it = reassembly_buffers_.find(key);
+    if (it == reassembly_buffers_.end()) {
+        return false;
+    }
+
+    const auto& buffer = it->second;
+    total_bytes = buffer.total_length;
+
+    received_bytes = 0;
+    for (bool const received : buffer.received_segments) {
+        if (received) {
+            ++received_bytes;
+        }
+    }
+
+    return true;
+}
+
 /**
  * @brief Cancel reassembly for a message
  * @implements REQ_TP_079
@@ -355,6 +388,11 @@ void TpReassembler::cancel_reassembly(uint32_t message_id) {
             ++it;
         }
     }
+}
+
+void TpReassembler::cancel_reassembly(const TpReassemblyKey& key) {
+    platform::ScopedLock const lock(buffers_mutex_);
+    reassembly_buffers_.erase(key);
 }
 
 /**

--- a/src/transport/tcp_transport.cpp
+++ b/src/transport/tcp_transport.cpp
@@ -667,16 +667,26 @@ bool TcpTransport::is_magic_cookie(const platform::ByteBuffer& data, size_t offs
     if (offset + SOMEIP_HEADER_SIZE > data.size()) {
         return false;
     }
-    return data[offset + 0] == 0xFF && data[offset + 1] == 0xFF &&
-           (data[offset + 2] == 0x00 || data[offset + 2] == 0x80) &&
-           data[offset + 3] == 0x00 &&
-           data[offset + 4] == 0x00 && data[offset + 5] == 0x00 &&
-           data[offset + 6] == 0x00 && data[offset + 7] == 0x08 &&
-           data[offset + 8] == 0xDE && data[offset + 9] == 0xAD &&
-           data[offset + 10] == 0xBE && data[offset + 11] == 0xEF &&
-           data[offset + 12] == 0x01 && data[offset + 13] == 0x01 &&
-           (data[offset + 14] == 0x01 || data[offset + 14] == 0x02) &&
-           data[offset + 15] == 0x00;
+    // Common fields: Service 0xFFFF, Length 8, Client 0xDEAD, Session 0xBEEF,
+    // Proto 1, Iface 1, RetCode 0.
+    // Method ID and Message Type must correlate:
+    //   Client cookie: Method 0x0000, MsgType 0x01 (REQUEST)
+    //   Server cookie: Method 0x8000, MsgType 0x02 (NOTIFICATION)
+    const bool common =
+        data[offset + 0] == 0xFF && data[offset + 1] == 0xFF &&
+        data[offset + 3] == 0x00 &&
+        data[offset + 4] == 0x00 && data[offset + 5] == 0x00 &&
+        data[offset + 6] == 0x00 && data[offset + 7] == 0x08 &&
+        data[offset + 8] == 0xDE && data[offset + 9] == 0xAD &&
+        data[offset + 10] == 0xBE && data[offset + 11] == 0xEF &&
+        data[offset + 12] == 0x01 && data[offset + 13] == 0x01 &&
+        data[offset + 15] == 0x00;
+    if (!common) {
+        return false;
+    }
+    const bool is_client = data[offset + 2] == 0x00 && data[offset + 14] == 0x01;
+    const bool is_server = data[offset + 2] == 0x80 && data[offset + 14] == 0x02;
+    return is_client || is_server;
 }
 
 platform::ByteBuffer TcpTransport::make_magic_cookie_client() {

--- a/tests/test_tcp_transport.cpp
+++ b/tests/test_tcp_transport.cpp
@@ -779,6 +779,30 @@ TEST_F(TcpTransportTest, IsMagicCookieDetection) {
 }
 
 /**
+ * @test_case TC_TCP_MAGIC_CORRELATION
+ * @tests feat_req_someip_609
+ * @brief Method ID and Message Type must correlate: client 0x0000/0x01,
+ *        server 0x8000/0x02. Crossed combinations are NOT valid cookies.
+ */
+TEST_F(TcpTransportTest, MagicCookieMethodTypeCorrelation) {
+    // Client cookie with wrong message type (0x02 instead of 0x01)
+    auto bad_client = TcpTransport::make_magic_cookie_client();
+    bad_client[14] = 0x02;
+    EXPECT_FALSE(TcpTransport::is_magic_cookie(bad_client))
+        << "Client method 0x0000 + type 0x02 must NOT be a valid cookie";
+
+    // Server cookie with wrong message type (0x01 instead of 0x02)
+    auto bad_server = TcpTransport::make_magic_cookie_server();
+    bad_server[14] = 0x01;
+    EXPECT_FALSE(TcpTransport::is_magic_cookie(bad_server))
+        << "Server method 0x8000 + type 0x01 must NOT be a valid cookie";
+
+    // Correct cookies still match
+    EXPECT_TRUE(TcpTransport::is_magic_cookie(TcpTransport::make_magic_cookie_client()));
+    EXPECT_TRUE(TcpTransport::is_magic_cookie(TcpTransport::make_magic_cookie_server()));
+}
+
+/**
  * @test_case TC_TCP_MAGIC_004
  * @tests REQ_TRANSPORT_020
  * @brief Magic Cookie in stream is silently consumed by parser

--- a/tests/test_tp.cpp
+++ b/tests/test_tp.cpp
@@ -1389,3 +1389,183 @@ TEST_F(TpTest, E2eBelowThresholdPassesSingleMessage) {
     ASSERT_EQ(segments.size(), 1u);
     EXPECT_EQ(segments[0].header.message_type, TpMessageType::SINGLE_MESSAGE);
 }
+
+/**
+ * @test_case TC_TP_MISMATCHED_MSG_LEN_REJECTED
+ * @tests REQ_TP_030_E02
+ * @brief Follow-up segment with mismatched message_length is rejected but
+ *        the active buffer is preserved.
+ */
+TEST_F(TpTest, MismatchedMessageLengthRejectedBufferPreserved) {
+    TpReassembler reassembler(config);
+
+    auto make_seg = [](uint32_t msg_len, uint32_t offset, bool more,
+                       TpMessageType tp_type, uint16_t session) {
+        TpSegment seg;
+        seg.header.message_length = msg_len;
+        seg.header.segment_offset = offset;
+        seg.header.segment_length = 40;
+        seg.header.sequence_number = 1;
+        seg.header.message_type = tp_type;
+        seg.header.service_id = 0x1111;
+        seg.header.method_id = 0x2222;
+        seg.header.client_id = 0xAAAA;
+        seg.header.session_id = session;
+        seg.header.protocol_version = 1;
+        seg.header.interface_version = 1;
+        seg.payload.resize(40, 0x00);
+        seg.payload[0] = 0x11; seg.payload[1] = 0x11;
+        seg.payload[2] = 0x22; seg.payload[3] = 0x22;
+        seg.payload[8] = 0xAA; seg.payload[9] = 0xAA;
+        seg.payload[10] = static_cast<uint8_t>(session >> 8U);
+        seg.payload[11] = static_cast<uint8_t>(session & 0xFFU);
+        seg.payload[12] = 0x01; seg.payload[13] = 0x01;
+        seg.payload[14] = 0x20; seg.payload[15] = 0x00;
+        uint32_t tp_hdr = ((offset / 16) << 4U) | (more ? 0x01U : 0x00U);
+        seg.payload[16] = static_cast<uint8_t>((tp_hdr >> 24U) & 0xFFU);
+        seg.payload[17] = static_cast<uint8_t>((tp_hdr >> 16U) & 0xFFU);
+        seg.payload[18] = static_cast<uint8_t>((tp_hdr >> 8U) & 0xFFU);
+        seg.payload[19] = static_cast<uint8_t>(tp_hdr & 0xFFU);
+        return seg;
+    };
+
+    // FIRST segment: message_length = 100
+    platform::ByteBuffer complete;
+    ASSERT_TRUE(reassembler.process_segment(
+        make_seg(100, 0, true, TpMessageType::FIRST_SEGMENT, 0x0001), complete));
+    ASSERT_EQ(reassembler.get_active_reassemblies(), 1u);
+
+    // CONSECUTIVE with mismatched message_length = 200
+    EXPECT_FALSE(reassembler.process_segment(
+        make_seg(200, 32, true, TpMessageType::CONSECUTIVE_SEGMENT, 0x0001), complete));
+    EXPECT_EQ(reassembler.get_active_reassemblies(), 1u)
+        << "Buffer must be preserved when a segment is rejected for message_length mismatch";
+}
+
+/**
+ * @test_case TC_TP_PLACEMENT_FAILURE_PRESERVES_BUFFER
+ * @tests REQ_TP_039_E01
+ * @brief Placement failure (offset past total_length) does not erase the buffer.
+ */
+TEST_F(TpTest, PlacementFailurePreservesBuffer) {
+    TpReassembler reassembler(config);
+
+    auto make_seg = [](uint32_t msg_len, uint32_t offset, bool more,
+                       TpMessageType tp_type) {
+        TpSegment seg;
+        seg.header.message_length = msg_len;
+        seg.header.segment_offset = offset;
+        seg.header.segment_length = 40;
+        seg.header.sequence_number = 1;
+        seg.header.message_type = tp_type;
+        seg.header.service_id = 0x1111;
+        seg.header.method_id = 0x2222;
+        seg.header.client_id = 0xAAAA;
+        seg.header.session_id = 0x0001;
+        seg.header.protocol_version = 1;
+        seg.header.interface_version = 1;
+        seg.payload.resize(40, 0x00);
+        seg.payload[0] = 0x11; seg.payload[1] = 0x11;
+        seg.payload[2] = 0x22; seg.payload[3] = 0x22;
+        seg.payload[8] = 0xAA; seg.payload[9] = 0xAA;
+        seg.payload[10] = 0x00; seg.payload[11] = 0x01;
+        seg.payload[12] = 0x01; seg.payload[13] = 0x01;
+        seg.payload[14] = 0x20; seg.payload[15] = 0x00;
+        uint32_t tp_hdr = ((offset / 16) << 4U) | (more ? 0x01U : 0x00U);
+        seg.payload[16] = static_cast<uint8_t>((tp_hdr >> 24U) & 0xFFU);
+        seg.payload[17] = static_cast<uint8_t>((tp_hdr >> 16U) & 0xFFU);
+        seg.payload[18] = static_cast<uint8_t>((tp_hdr >> 8U) & 0xFFU);
+        seg.payload[19] = static_cast<uint8_t>(tp_hdr & 0xFFU);
+        return seg;
+    };
+
+    // FIRST segment: message_length = 48, offset 0, 20 payload bytes
+    platform::ByteBuffer complete;
+    ASSERT_TRUE(reassembler.process_segment(
+        make_seg(48, 0, true, TpMessageType::FIRST_SEGMENT), complete));
+    ASSERT_EQ(reassembler.get_active_reassemblies(), 1u);
+
+    // CONSECUTIVE with wire offset 48 — past total_length, same message_length
+    // validate_segment will reject because 48 > 48 (wire_offset > message_length)
+    EXPECT_FALSE(reassembler.process_segment(
+        make_seg(48, 48, false, TpMessageType::LAST_SEGMENT), complete));
+    EXPECT_EQ(reassembler.get_active_reassemblies(), 1u)
+        << "Buffer must be preserved after placement failure";
+}
+
+/**
+ * @test_case TC_TP_KEY_API_TARGETS_EXACT_KEY
+ * @tests feat_req_someiptp_781
+ * @brief Key-based API targets only the exact transfer; a second transfer
+ *        with the same message_id but different client/session is unaffected.
+ */
+TEST_F(TpTest, KeyBasedApiTargetsExactKey) {
+    TpReassembler reassembler(config);
+
+    auto make_seg = [](uint16_t client, uint16_t session) {
+        TpSegment seg;
+        seg.header.message_length = 100;
+        seg.header.segment_offset = 0;
+        seg.header.segment_length = 40;
+        seg.header.sequence_number = 1;
+        seg.header.message_type = TpMessageType::FIRST_SEGMENT;
+        seg.header.service_id = 0x1111;
+        seg.header.method_id = 0x2222;
+        seg.header.client_id = client;
+        seg.header.session_id = session;
+        seg.header.protocol_version = 1;
+        seg.header.interface_version = 1;
+        seg.payload.resize(40, 0x00);
+        seg.payload[0] = 0x11; seg.payload[1] = 0x11;
+        seg.payload[2] = 0x22; seg.payload[3] = 0x22;
+        seg.payload[8] = static_cast<uint8_t>(client >> 8U);
+        seg.payload[9] = static_cast<uint8_t>(client & 0xFFU);
+        seg.payload[10] = static_cast<uint8_t>(session >> 8U);
+        seg.payload[11] = static_cast<uint8_t>(session & 0xFFU);
+        seg.payload[12] = 0x01; seg.payload[13] = 0x01;
+        seg.payload[14] = 0x20; seg.payload[15] = 0x00;
+        seg.payload[16] = 0x00; seg.payload[17] = 0x00;
+        seg.payload[18] = 0x00; seg.payload[19] = 0x01;
+        return seg;
+    };
+
+    platform::ByteBuffer complete;
+    ASSERT_TRUE(reassembler.process_segment(make_seg(0xAAAA, 0x0001), complete));
+    ASSERT_TRUE(reassembler.process_segment(make_seg(0xBBBB, 0x0002), complete));
+    ASSERT_EQ(reassembler.get_active_reassemblies(), 2u);
+
+    // Both share message_id = 0x11112222
+    const uint32_t msg_id = (0x1111u << 16U) | 0x2222u;
+    EXPECT_TRUE(reassembler.is_reassembling(msg_id));
+
+    // Build exact key for transfer A
+    TpReassemblyKey key_a;
+    key_a.message_id = msg_id;
+    key_a.protocol_version = 1;
+    key_a.interface_version = 1;
+    key_a.message_type = 0x00;
+    key_a.request_id = (static_cast<uint32_t>(0xAAAA) << 16U) | 0x0001;
+
+    TpReassemblyKey key_b;
+    key_b.message_id = msg_id;
+    key_b.protocol_version = 1;
+    key_b.interface_version = 1;
+    key_b.message_type = 0x00;
+    key_b.request_id = (static_cast<uint32_t>(0xBBBB) << 16U) | 0x0002;
+
+    EXPECT_TRUE(reassembler.is_reassembling(key_a));
+    EXPECT_TRUE(reassembler.is_reassembling(key_b));
+
+    uint32_t received = 0;
+    uint32_t total = 0;
+    EXPECT_TRUE(reassembler.get_reassembly_progress(key_a, received, total));
+    EXPECT_EQ(total, 100u);
+    EXPECT_EQ(received, 20u);
+
+    // Cancel only transfer A
+    reassembler.cancel_reassembly(key_a);
+    EXPECT_FALSE(reassembler.is_reassembling(key_a));
+    EXPECT_TRUE(reassembler.is_reassembling(key_b))
+        << "cancel_reassembly(key) must not affect other transfers with the same message_id";
+    EXPECT_EQ(reassembler.get_active_reassemblies(), 1u);
+}


### PR DESCRIPTION
## Summary

- **Deserializer**: overflow-safe bounds check in `deserialize_string` — replaces `position_ + length > buffer_.size()` with a split comparison to avoid `uint32_t` wrap on 32-bit targets (ARM Cortex-M).
- **TP reassembler**: rejects follow-up segments whose `message_length` disagrees with the buffer's `total_length`, preventing rogue segments from corrupting or erasing active reassembly. Stops erasing the buffer on placement failure.
- **TCP Magic Cookie**: correlates method ID with message type so only the two spec-defined cookie variants are accepted (client: method `0x0000` + type `0x01`; server: method `0x8000` + type `0x02`). Previously accepted any combination.
- **TpReassembler API**: adds `TpReassemblyKey`-based overloads for `is_reassembling`, `get_reassembly_progress`, and `cancel_reassembly` so callers can target an exact transfer.

All items were identified during PR #278 review and deferred as out-of-scope for that patch.

## Test plan

- [x] `test_tp` — 43 tests pass
- [x] `test_serialization` — 60 tests pass
- [x] `test_tcp_transport` — 30 tests pass
- [x] CI (clang-tidy, ASan, FreeRTOS, ThreadX, Zephyr, Windows)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added precise controls for checking status, tracking progress, and cancelling specific message reassemblies.
  * Clarified behavior when multiple reassemblies share the same message ID.

* **Bug Fixes**
  * Prevented inconsistent or invalid segments from corrupting active reassembly.
  * Improved protection against oversized or malformed serialized strings.
  * Strengthened magic-cookie validation by requiring valid method and message-type combinations.

* **Tests**
  * Added coverage for exact-key reassembly operations and correlated magic-cookie validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->